### PR TITLE
Simpler context key

### DIFF
--- a/src/context-registry.spec.ts
+++ b/src/context-registry.spec.ts
@@ -1,4 +1,3 @@
-import { AIterable } from '@proc7ts/a-iterable';
 import { valueProvider } from '@proc7ts/call-thru';
 import { ContextRegistry } from './context-registry';
 import { ContextValues } from './context-values';
@@ -29,7 +28,7 @@ describe('ContextRegistry', () => {
     });
     it('respects seed fallback', () => {
       expect(values.get(key.seedKey, { or: valueProvider('default') })()).toBe('default');
-      expect([...values.get(multiKey.seedKey, { or: AIterable.from(['default']) })]).toEqual(['default']);
+      expect([...values.get(multiKey.seedKey, { or: ['default'] })]).toEqual(['default']);
     });
     it('prefers explicit seed', () => {
 
@@ -38,7 +37,7 @@ describe('ContextRegistry', () => {
       mockProvider.mockReturnValue(value);
 
       expect(values.get(key.seedKey, { or: valueProvider('default') })()).toBe(value);
-      expect([...values.get(multiKey.seedKey, { or: AIterable.from(['default']) })]).toEqual([value]);
+      expect([...values.get(multiKey.seedKey, { or: ['default'] })]).toEqual([value]);
     });
     it('caches value seed', () => {
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,6 @@ export * from './context-registry';
 export * from './context-seeder';
 export * from './context-value-spec';
 export * from './context-values';
+export * from './iterative-context-key';
 export * from './multi-context-key';
-export * from './simple-context-key';
 export * from './single-context-key';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,5 @@ export * from './context-value-spec';
 export * from './context-values';
 export * from './iterative-context-key';
 export * from './multi-context-key';
+export * from './simple-context-key';
 export * from './single-context-key';

--- a/src/iterative-context-key.ts
+++ b/src/iterative-context-key.ts
@@ -9,7 +9,10 @@ import { ContextSeeder } from './context-seeder';
 import { ContextValueProvider } from './context-value-spec';
 import { ContextValues } from './context-values';
 
-class SimpleContextSeeder<Ctx extends ContextValues, Src> implements ContextSeeder<Ctx, Src, AIterable<Src>> {
+/**
+ * @internal
+ */
+class IterativeContextSeeder<Ctx extends ContextValues, Src> implements ContextSeeder<Ctx, Src, AIterable<Src>> {
 
   private readonly _providers: ContextValueProvider<Ctx, Src>[] = [];
 
@@ -42,25 +45,28 @@ class SimpleContextSeeder<Ctx extends ContextValues, Src> implements ContextSeed
 
 }
 
-class SimpleSeedKey<Src> extends ContextSeedKey<Src, AIterable<Src>> {
+/**
+ * @internal
+ */
+class IterativeSeedKey<Src> extends ContextSeedKey<Src, AIterable<Src>> {
 
-  seeder<Ctx extends ContextValues>(): SimpleContextSeeder<Ctx, Src> {
-    return new SimpleContextSeeder();
+  seeder<Ctx extends ContextValues>(): IterativeContextSeeder<Ctx, Src> {
+    return new IterativeContextSeeder();
   }
 
 }
 
 /**
- * Simple context value key implementation.
+ * Iterative context value key implementation.
  *
- * Collects value sources into iterable instance.
+ * Collects value sources as iterable instance.
  *
  * A context value associated with this key is never changes once constructed.
  *
  * @typeparam Value  Context value type.
  * @typeparam Src  Source value type.
  */
-export abstract class SimpleContextKey<Value, Src = Value> extends ContextKey<Value, Src, AIterable<Src>> {
+export abstract class IterativeContextKey<Value, Src = Value> extends ContextKey<Value, Src, AIterable<Src>> {
 
   readonly seedKey: ContextSeedKey<Src, AIterable<Src>>;
 
@@ -72,7 +78,7 @@ export abstract class SimpleContextKey<Value, Src = Value> extends ContextKey<Va
    */
   constructor(name: string, seedKey?: ContextSeedKey<Src, AIterable<Src>>) {
     super(name);
-    this.seedKey = seedKey || new SimpleSeedKey(this);
+    this.seedKey = seedKey || new IterativeSeedKey(this);
   }
 
 }

--- a/src/iterative-context-key.ts
+++ b/src/iterative-context-key.ts
@@ -31,7 +31,7 @@ class IterativeContextSeeder<Ctx extends ContextValues, Src> implements ContextS
   seed(context: Ctx, initial: AIterable<Src> = AIterable.from(overNone())): AIterable<Src> {
     return AIterable.from([
       initial,
-      sourceValues(context, this._providers),
+      iterativeSeed(context, this._providers),
     ]).flatMap(asis);
   }
 
@@ -71,7 +71,7 @@ export abstract class IterativeContextKey<Value, Src = Value> extends ContextKey
   readonly seedKey: ContextSeedKey<Src, AIterable<Src>>;
 
   /**
-   * Constructs simple context value key.
+   * Constructs iterative context value key.
    *
    * @param name  Human-readable key name.
    * @param seedKey  Value seed key. A new one will be constructed when omitted.
@@ -93,9 +93,9 @@ type SourceEntry<Ctx extends ContextValues, Src> = [ContextValueProvider<Ctx, Sr
 /**
  * @internal
  */
-function sourceValues<Ctx extends ContextValues, Src>(
+function iterativeSeed<Ctx extends ContextValues, Src>(
     context: Ctx,
-    providers: ContextValueProvider<Ctx, Src>[],
+    providers: readonly ContextValueProvider<Ctx, Src>[],
 ): AIterable<Src> {
   return AIterable.from(overArray(providers.map<SourceEntry<Ctx, Src>>(provider => [provider])))
       .map(entry => {

--- a/src/multi-context-key.ts
+++ b/src/multi-context-key.ts
@@ -7,7 +7,7 @@ import { valuesProvider } from '@proc7ts/call-thru';
 import { ContextKey, ContextKeyDefault, ContextSeedKey, ContextValueOpts } from './context-key';
 import { ContextRef } from './context-ref';
 import { ContextValues } from './context-values';
-import { SimpleContextKey } from './simple-context-key';
+import { IterativeContextKey } from './iterative-context-key';
 
 /**
  * Multiple context value reference.
@@ -28,7 +28,7 @@ export type MultiContextRef<Src> = ContextRef<readonly Src[], Src>;
  * @typeparam Src  Value source type and context value item type.
  */
 export class MultiContextKey<Src>
-    extends SimpleContextKey<readonly Src[], Src>
+    extends IterativeContextKey<readonly Src[], Src>
     implements MultiContextRef<Src> {
 
   /**

--- a/src/multi-context-key.ts
+++ b/src/multi-context-key.ts
@@ -2,7 +2,6 @@
  * @packageDocumentation
  * @module @proc7ts/context-values
  */
-import { AIterable } from '@proc7ts/a-iterable';
 import { valuesProvider } from '@proc7ts/call-thru';
 import { ContextKey, ContextKeyDefault, ContextSeedKey, ContextValueOpts } from './context-key';
 import { ContextRef } from './context-ref';
@@ -49,7 +48,7 @@ export class MultiContextKey<Src>
         seedKey,
         byDefault = valuesProvider(),
       }: {
-        seedKey?: ContextSeedKey<Src, AIterable<Src>>;
+        seedKey?: ContextSeedKey<Src, Iterable<Src>>;
         byDefault?: ContextKeyDefault<readonly Src[], ContextKey<readonly Src[], Src>>;
       } = {},
   ) {
@@ -58,7 +57,7 @@ export class MultiContextKey<Src>
   }
 
   grow<Ctx extends ContextValues>(
-      opts: ContextValueOpts<Ctx, readonly Src[], Src, AIterable<Src>>,
+      opts: ContextValueOpts<Ctx, readonly Src[], Src, Iterable<Src>>,
   ): readonly Src[] | null | undefined {
 
     const result = Array.from(opts.seed);

--- a/src/simple-context-key.ts
+++ b/src/simple-context-key.ts
@@ -1,0 +1,153 @@
+/**
+ * @packageDocumentation
+ * @module @proc7ts/context-values
+ */
+import { noop, valueProvider } from '@proc7ts/call-thru';
+import { ContextKey, ContextSeedKey } from './context-key';
+import { ContextSeeder } from './context-seeder';
+import { ContextValueProvider } from './context-value-spec';
+import { ContextValues } from './context-values';
+
+/**
+ * @internal
+ */
+class SimpleContextSeeder<Ctx extends ContextValues, Src>
+    implements ContextSeeder<Ctx, Src, SimpleContextKey.Seed<Src>> {
+
+  private readonly _providers: ContextValueProvider<Ctx, Src>[] = [];
+
+  provide(provider: ContextValueProvider<Ctx, Src>): () => void {
+    this._providers.unshift(provider);
+    return () => {
+
+      const found = this._providers.lastIndexOf(provider);
+
+      if (found >= 0) {
+        this._providers.splice(found, 1);
+      }
+    };
+  }
+
+  seed(context: Ctx, initial: SimpleContextKey.Seed<Src>): SimpleContextKey.Seed<Src> {
+
+    let seeds = this._providers.map(provider => simpleSeedByProvider(context, provider));
+
+    if (initial) {
+      if (!this._providers.length) {
+        return initial;
+      }
+      seeds = [...seeds, initial];
+    } else if (seeds.length < 2) {
+      return seeds.length ? seeds[0] : noop;
+    }
+
+    return combineSimpleSeeds(seeds);
+  }
+
+  isEmpty(seed: SimpleContextKey.Seed<Src>): boolean {
+    return seed() == null;
+  }
+
+  combine(
+      first: SimpleContextKey.Seed<Src>,
+      second: SimpleContextKey.Seed<Src>,
+  ): SimpleContextKey.Seed<Src> {
+    if (first === noop) {
+      return second;
+    }
+    if (second === noop) {
+      return first;
+    }
+    return combineSimpleSeeds([second, first]);
+  }
+
+
+}
+
+/**
+ * @internal
+ */
+function simpleSeedByProvider<Ctx extends ContextValues, Src>(
+    context: Ctx,
+    provider: ContextValueProvider<Ctx, Src>,
+): SimpleContextKey.Seed<Src> {
+
+  let get = (): Src | null | undefined => {
+    get = valueProvider(provider(context));
+    return get();
+  };
+
+  return () => get();
+}
+
+/**
+ * @internal
+ */
+function combineSimpleSeeds<Src>(
+    seeds: readonly SimpleContextKey.Seed<Src>[],
+): SimpleContextKey.Seed<Src> {
+  return () => {
+    for (const seed of seeds) {
+
+      const value = seed();
+
+      if (value != null) {
+        return value;
+      }
+    }
+    return;
+  };
+}
+
+/**
+ * @internal
+ */
+class SimpleSeedKey<Src> extends ContextSeedKey<Src, SimpleContextKey.Seed<Src>> {
+
+  seeder<Ctx extends ContextValues>(): SimpleContextSeeder<Ctx, Src> {
+    return new SimpleContextSeeder();
+  }
+
+}
+
+/**
+ * Simple context value key implementation.
+ *
+ * Collects the most recent source value.
+ *
+ * A context value associated with this key is never changes once constructed.
+ *
+ * @typeparam Value  Context value type.
+ * @typeparam Src  Source value type.
+ */
+export abstract class SimpleContextKey<Value, Src = Value> extends ContextKey<Value, Src, SimpleContextKey.Seed<Src>> {
+
+  readonly seedKey: ContextSeedKey<Src, SimpleContextKey.Seed<Src>>;
+
+  /**
+   * Constructs simple context value key.
+   *
+   * @param name  Human-readable key name.
+   * @param seedKey  Value seed key. A new one will be constructed when omitted.
+   */
+  constructor(name: string, seedKey?: ContextSeedKey<Src, SimpleContextKey.Seed<Src>>) {
+    super(name);
+    this.seedKey = seedKey || new SimpleSeedKey(this);
+  }
+
+}
+
+export namespace SimpleContextKey {
+
+  /**
+   * A seed of {@link SimpleContextKey simple context key}.
+   *
+   * @typeparam Src  Source vale type.
+   */
+  export type Seed<Src> =
+  /**
+   * @returns Either source value, or `null`/`undefined` when when absent.
+   */
+      (this: void) => Src | null | undefined;
+
+}

--- a/src/single-context-key.ts
+++ b/src/single-context-key.ts
@@ -7,7 +7,7 @@ import { noop } from '@proc7ts/call-thru';
 import { ContextKey, ContextKeyDefault, ContextSeedKey, ContextValueOpts } from './context-key';
 import { ContextRef } from './context-ref';
 import { ContextValues } from './context-values';
-import { SimpleContextKey } from './simple-context-key';
+import { IterativeContextKey } from './iterative-context-key';
 
 /**
  * Single context value reference.
@@ -24,7 +24,7 @@ export type SingleContextRef<Value> = ContextRef<Value, Value>;
  * @typeparam Value  Context value type.
  */
 export class SingleContextKey<Value>
-    extends SimpleContextKey<Value>
+    extends IterativeContextKey<Value>
     implements SingleContextRef<Value> {
 
   /**

--- a/src/single-context-key.ts
+++ b/src/single-context-key.ts
@@ -2,12 +2,11 @@
  * @packageDocumentation
  * @module @proc7ts/context-values
  */
-import { AIterable, itsLast } from '@proc7ts/a-iterable';
 import { noop } from '@proc7ts/call-thru';
 import { ContextKey, ContextKeyDefault, ContextSeedKey, ContextValueOpts } from './context-key';
 import { ContextRef } from './context-ref';
 import { ContextValues } from './context-values';
-import { IterativeContextKey } from './iterative-context-key';
+import { SimpleContextKey } from './simple-context-key';
 
 /**
  * Single context value reference.
@@ -24,7 +23,7 @@ export type SingleContextRef<Value> = ContextRef<Value, Value>;
  * @typeparam Value  Context value type.
  */
 export class SingleContextKey<Value>
-    extends IterativeContextKey<Value>
+    extends SimpleContextKey<Value>
     implements SingleContextRef<Value> {
 
   /**
@@ -46,7 +45,7 @@ export class SingleContextKey<Value>
         seedKey,
         byDefault = noop,
       }: {
-        seedKey?: ContextSeedKey<Value, AIterable<Value>>;
+        seedKey?: ContextSeedKey<Value, SimpleContextKey.Seed<Value>>;
         byDefault?: ContextKeyDefault<Value, ContextKey<Value>>;
       } = {},
   ) {
@@ -55,10 +54,10 @@ export class SingleContextKey<Value>
   }
 
   grow<Ctx extends ContextValues>(
-      opts: ContextValueOpts<Ctx, Value, Value, AIterable<Value>>,
+      opts: ContextValueOpts<Ctx, Value, Value, SimpleContextKey.Seed<Value>>,
   ): Value | null | undefined {
 
-    const value = itsLast(opts.seed);
+    const value = opts.seed();
 
     if (value != null) {
       return value;


### PR DESCRIPTION
- `SimpleContextKey` seed has single value now.
- Add `IterativeContextKey` with `Iterable` seed.
- `MultiContextKey` extends `IterativeContextKey`.