### PR TITLE
Context supply

### DIFF
--- a/src/updatable/context-destroyed.ts
+++ b/src/updatable/context-destroyed.ts
@@ -1,0 +1,16 @@
+/**
+ * @packageDocumentation
+ * @module @proc7ts/context-values/updatable
+ */
+/**
+ * Creates a function that throws a context destruction reason.
+ *
+ * This may be handy when {@link ContextSupply context supply} is cut off.
+ *
+ * @param reason  Context destruction reason.
+ */
+export function contextDestroyed(reason?: any): () => never {
+  return () => {
+    throw reason ?? new TypeError('Context destroyed');
+  };
+}

--- a/src/updatable/context-supply.spec.ts
+++ b/src/updatable/context-supply.spec.ts
@@ -1,0 +1,24 @@
+import { eventSupply, EventSupply__symbol, EventSupplyPeer } from '@proc7ts/fun-events';
+import { ContextRegistry } from '../context-registry';
+import { ContextValues } from '../context-values';
+import { ContextSupply } from './context-supply';
+
+describe('ContextSupply', () => {
+  it('is not defined by default', () => {
+
+    const values = new ContextRegistry().newValues();
+
+    expect(values.get(ContextSupply, { or: null })).toBeNull();
+  });
+  it('is equal to supply of context when context is a peer', () => {
+
+    const values = new ContextRegistry().newValues();
+    const supply = eventSupply();
+    const context: ContextValues & EventSupplyPeer = {
+      get: values.get,
+      [EventSupply__symbol]: supply,
+    };
+
+    expect(context.get(ContextSupply, { or: null })).toBe(supply);
+  });
+});

--- a/src/updatable/context-supply.spec.ts
+++ b/src/updatable/context-supply.spec.ts
@@ -1,4 +1,5 @@
 import { eventSupply, EventSupply__symbol, EventSupplyPeer } from '@proc7ts/fun-events';
+import { ContextKeyError } from '../context-key-error';
 import { ContextRegistry } from '../context-registry';
 import { ContextValues } from '../context-values';
 import { ContextSupply } from './context-supply';
@@ -9,6 +10,8 @@ describe('ContextSupply', () => {
     const values = new ContextRegistry().newValues();
 
     expect(values.get(ContextSupply, { or: null })).toBeNull();
+    expect(values.get(ContextSupply, { or: undefined })).toBeUndefined();
+    expect(() => values.get(ContextSupply)).toThrow(ContextKeyError);
   });
   it('is equal to supply of context when context is a peer', () => {
 
@@ -20,5 +23,38 @@ describe('ContextSupply', () => {
     };
 
     expect(context.get(ContextSupply, { or: null })).toBe(supply);
+    expect(context.get(ContextSupply, { or: undefined })).toBe(supply);
+    expect(context.get(ContextSupply)).toBe(supply);
+  });
+  it('is equal to fallback when context is a peer and no value provided', () => {
+
+    const values = new ContextRegistry().newValues();
+    const supply = eventSupply();
+    const context: ContextValues & EventSupplyPeer = {
+      get: values.get,
+      [EventSupply__symbol]: supply,
+    };
+    const fallback = eventSupply();
+
+    expect(context.get(ContextSupply, { or: fallback })).toBe(fallback);
+  });
+  it('is equal to provided value when context is a peer', () => {
+
+    const registry = new ContextRegistry();
+    const provided = eventSupply();
+
+    registry.provide({ a: ContextSupply, is: provided });
+
+    const values = registry.newValues();
+    const supply = eventSupply();
+    const context: ContextValues & EventSupplyPeer = {
+      get: values.get,
+      [EventSupply__symbol]: supply,
+    };
+
+    expect(context.get(ContextSupply)).toBe(provided);
+    expect(context.get(ContextSupply, { or: eventSupply() })).toBe(provided);
+    expect(context.get(ContextSupply, { or: null })).toBe(provided);
+    expect(context.get(ContextSupply, { or: undefined })).toBe(provided);
   });
 });

--- a/src/updatable/context-supply.ts
+++ b/src/updatable/context-supply.ts
@@ -1,0 +1,47 @@
+/**
+ * @packageDocumentation
+ * @module @proc7ts/context-values/updatable
+ */
+import { noop } from '@proc7ts/call-thru';
+import { EventSupply, EventSupply__symbol, EventSupplyPeer } from '@proc7ts/fun-events';
+import { ContextValueOpts } from '../context-key';
+import { ContextRef } from '../context-ref';
+import { ContextValues } from '../context-values';
+import { SimpleContextKey } from '../simple-context-key';
+
+/**
+ * Context values supply.
+ *
+ * When available as context value, it is used to indicate the context is no longer used (e.g. destroyed).
+ *
+ * A context value provider can destroy the value it provides when this supply is cut off.
+ */
+export type ContextSupply = EventSupply;
+
+/**
+ * @internal
+ */
+class ContextSupplyKey extends SimpleContextKey<ContextSupply> {
+
+  constructor() {
+    super('context-supply');
+  }
+
+  grow<Ctx extends ContextValues>(
+      opts: ContextValueOpts<Ctx, ContextSupply, ContextSupply, SimpleContextKey.Seed<ContextSupply>>,
+  ): ContextSupply | null | undefined {
+    return opts.seed()
+        || (opts.context as Partial<EventSupplyPeer>)[EventSupply__symbol]
+        || opts.byDefault(noop);
+  }
+
+}
+
+/**
+ * A key of context value containing a {@link ContextSupply context values supply}.
+ *
+ * It is not guaranteed to present.
+ *
+ * Predefined to the supply of the context if the latter implements `EventSupplyPeer` interface.
+ */
+export const ContextSupply: ContextRef<ContextSupply> = (/*#__PURE__*/ new ContextSupplyKey());

--- a/src/updatable/context-supply.ts
+++ b/src/updatable/context-supply.ts
@@ -31,6 +31,7 @@ class ContextSupplyKey extends SimpleContextKey<ContextSupply> {
       opts: ContextValueOpts<Ctx, ContextSupply, ContextSupply, SimpleContextKey.Seed<ContextSupply>>,
   ): ContextSupply | null | undefined {
     return opts.seed()
+        || opts.or
         || (opts.context as Partial<EventSupplyPeer>)[EventSupply__symbol]
         || opts.byDefault(noop);
   }

--- a/src/updatable/index.ts
+++ b/src/updatable/index.ts
@@ -1,3 +1,5 @@
+export * from './context-destroyed';
+export * from './context-supply';
 export * from './context-up-key';
 export * from './fn-context-key';
 export * from './multi-context-up-key';

--- a/src/updatable/multi-context-up-key.spec.ts
+++ b/src/updatable/multi-context-up-key.spec.ts
@@ -1,7 +1,8 @@
-import { AfterEvent, afterThe } from '@proc7ts/fun-events';
+import { AfterEvent, afterThe, eventSupply } from '@proc7ts/fun-events';
 import { ContextKeyError } from '../context-key-error';
 import { ContextRegistry } from '../context-registry';
 import { ContextValues } from '../context-values';
+import { ContextSupply } from './context-supply';
 import { MultiContextUpKey } from './multi-context-up-key';
 
 describe('MultiContextUpKey', () => {
@@ -20,17 +21,17 @@ describe('MultiContextUpKey', () => {
     key = new MultiContextUpKey('values');
   });
 
-  it('is associated with empty array by default', () => {
+  it('provides empty array by default', () => {
     expect(readValue(values.get(key))).toHaveLength(0);
   });
-  it('is associated with default value if there is no provider', () => {
+  it('provides default value if there is no provider', () => {
 
     const defaultValue = ['default'];
     const keyWithDefaults = new MultiContextUpKey('key', { byDefault: () => defaultValue });
 
     expect(readValue(values.get(keyWithDefaults))).toEqual(defaultValue);
   });
-  it('is associated with default value if providers did not return any values', () => {
+  it('provides default value if providers did not return any values', () => {
 
     const defaultValue = ['default'];
     const byDefault = jest.fn(() => defaultValue);
@@ -42,19 +43,19 @@ describe('MultiContextUpKey', () => {
     expect(readValue(values.get(keyWithDefaults))).toEqual(defaultValue);
     expect(byDefault).toHaveBeenCalledWith(values, keyWithDefaults);
   });
-  it('is associated with provided values array', () => {
+  it('provides an array of values', () => {
     registry.provide({ a: key, is: 'a' });
     registry.provide({ a: key, is: undefined });
     registry.provide({ a: key, is: 'c' });
 
     expect(readValue(values.get(key))).toEqual(['a', 'c']);
   });
-  it('is associated with value', () => {
+  it('provides an array of single value', () => {
     registry.provide({ a: key, is: 'value' });
 
     expect(readValue(values.get(key))).toEqual(['value']);
   });
-  it('is associated with fallback value if there is no value provided', () => {
+  it('provides fallback value if there is no value provided', () => {
     expect(readValue(values.get(key, { or: afterThe('fallback') }))).toEqual(['fallback']);
   });
   it('prefers fallback value over default one', () => {
@@ -73,6 +74,25 @@ describe('MultiContextUpKey', () => {
   });
   it('throws if fallback value is `undefined`', () => {
     expect(() => readValue(values.get(key, { or: undefined })!)).toThrow(ContextKeyError);
+  });
+  it('cuts off the value supply after context destruction', () => {
+
+    const value = 'test value';
+    const contextSupply = eventSupply();
+
+    registry.provide({ a: ContextSupply, is: contextSupply });
+    registry.provide({ a: key, is: value });
+
+    const receiver = jest.fn();
+    const whenOff = jest.fn();
+
+    values.get(key).to(receiver).whenOff(whenOff);
+    expect(receiver).toHaveBeenCalledWith(value);
+
+    const reason = new Error('reason');
+
+    contextSupply.off(reason);
+    expect(whenOff).toHaveBeenCalledWith(reason);
   });
 
   describe('upKey', () => {

--- a/src/updatable/multi-context-up-key.ts
+++ b/src/updatable/multi-context-up-key.ts
@@ -7,6 +7,7 @@ import { AfterEvent, afterEventBy, afterThe, EventKeeper, nextAfterEvent } from 
 import { ContextKeyDefault, ContextSeedKey, ContextValueOpts } from '../context-key';
 import { ContextKeyError } from '../context-key-error';
 import { ContextValues } from '../context-values';
+import { ContextSupply } from './context-supply';
 import { ContextUpKey, ContextUpRef } from './context-up-key';
 
 /**
@@ -65,7 +66,8 @@ export class MultiContextUpKey<Src>
   grow<Ctx extends ContextValues>(
       opts: ContextValueOpts<Ctx, AfterEvent<Src[]>, EventKeeper<Src[]> | Src, AfterEvent<Src[]>>,
   ): AfterEvent<Src[]> {
-    return opts.seed.keepThru((...sources) => {
+
+    const value = opts.seed.keepThru((...sources) => {
       if (sources.length) {
         // Sources present. Use them.
         return nextArgs(...sources);
@@ -88,6 +90,10 @@ export class MultiContextUpKey<Src>
         throw new ContextKeyError(this);
       }));
     });
+
+    const supply = opts.context.get(ContextSupply, { or: null });
+
+    return supply ? value.tillOff(supply) : value;
   }
 
 }

--- a/src/updatable/single-context-up-key.spec.ts
+++ b/src/updatable/single-context-up-key.spec.ts
@@ -1,7 +1,8 @@
-import { AfterEvent, afterThe } from '@proc7ts/fun-events';
+import { AfterEvent, afterThe, eventSupply } from '@proc7ts/fun-events';
 import { ContextKeyError } from '../context-key-error';
 import { ContextRegistry } from '../context-registry';
 import { ContextValues } from '../context-values';
+import { ContextSupply } from './context-supply';
 import { SingleContextUpKey } from './single-context-up-key';
 
 describe('SingleContextUpKey', () => {
@@ -53,6 +54,25 @@ describe('SingleContextUpKey', () => {
     registry.provide({ a: key, is: value2 })();
 
     expect(readValue(values.get(key))).toBe(value1);
+  });
+  it('cuts off the value supply after context destruction', () => {
+
+    const value = 'test value';
+    const contextSupply = eventSupply();
+
+    registry.provide({ a: ContextSupply, is: contextSupply });
+    registry.provide({ a: key, is: value });
+
+    const receiver = jest.fn();
+    const whenOff = jest.fn();
+
+    values.get(key).to(receiver).whenOff(whenOff);
+    expect(receiver).toHaveBeenCalledWith(value);
+
+    const reason = new Error('reason');
+
+    contextSupply.off(reason);
+    expect(whenOff).toHaveBeenCalledWith(reason);
   });
   it('updates the value when specifier removed', () => {
 

--- a/src/updatable/single-context-up-key.ts
+++ b/src/updatable/single-context-up-key.ts
@@ -7,6 +7,7 @@ import { AfterEvent, afterEventBy, afterThe, EventKeeper, nextAfterEvent } from 
 import { ContextKeyDefault, ContextSeedKey, ContextValueOpts } from '../context-key';
 import { ContextKeyError } from '../context-key-error';
 import { ContextValues } from '../context-values';
+import { ContextSupply } from './context-supply';
 import { ContextUpKey, ContextUpRef } from './context-up-key';
 
 /**
@@ -65,7 +66,8 @@ export class SingleContextUpKey<Value>
   grow<Ctx extends ContextValues>(
       opts: ContextValueOpts<Ctx, AfterEvent<[Value]>, EventKeeper<Value[]> | Value, AfterEvent<Value[]>>,
   ): AfterEvent<[Value]> {
-    return opts.seed.keepThru((...sources: Value[]) => {
+
+    const value = opts.seed.keepThru((...sources: Value[]) => {
       if (sources.length) {
         // Sources present. Take the last one.
         return nextArg(sources[sources.length - 1]);
@@ -88,6 +90,10 @@ export class SingleContextUpKey<Value>
         throw new ContextKeyError(this);
       }));
     });
+
+    const supply = opts.context.get(ContextSupply, { or: null });
+
+    return supply ? value.tillOff(supply) : value;
   }
 
 }


### PR DESCRIPTION
`ContextSupply` is a supply that is cut off once context is destroyed.

It is predefined to the supply of context if the latter implements `EventSupplyPeer`.

Updatable context key implementations cut off their values supply once context supply is cut off.