### PR TITLE
Context value setup support

### DIFF
--- a/src/context-key.ts
+++ b/src/context-key.ts
@@ -65,7 +65,7 @@ export abstract class ContextKey<Value, Src = Value, Seed = unknown> implements 
    *
    * @returns Single context value, or `undefined` if there is no default value.
    */
-  abstract grow<Ctx extends ContextValues>(opts: ContextValueOpts<Ctx, Value, Src, Seed>): Value | null | undefined;
+  abstract grow(opts: ContextValueOpts<Value, Src, Seed>): Value | null | undefined;
 
   toString(): string {
     return `ContextKey(${this.name})`;
@@ -78,22 +78,21 @@ export abstract class ContextKey<Value, Src = Value, Seed = unknown> implements 
  *
  * An instance of these options is passed to [[ContextKey.grow]] method to provide the necessary value growth context.
  *
- * @typeparam Ctx  Context type.
  * @typeparam Value  Context value type.
  * @typeparam Src  Source value type.
  * @typeparam Seed  Value seed type.
  */
-export interface ContextValueOpts<Ctx extends ContextValues, Value, Src, Seed> {
+export interface ContextValueOpts<Value, Src, Seed> {
 
   /**
    * Target context.
    */
-  readonly context: Ctx;
+  readonly context: ContextValues;
 
   /**
    * Context value seeder.
    */
-  readonly seeder: ContextSeeder<Ctx, Src, Seed>;
+  readonly seeder: ContextSeeder<ContextValues, Src, Seed>;
 
   /**
    * Context value seed.
@@ -170,7 +169,7 @@ export abstract class ContextSeedKey<Src, Seed> extends ContextKey<Seed, Src, Se
    */
   abstract seeder<Ctx extends ContextValues>(): ContextSeeder<Ctx, Src, Seed>;
 
-  grow<Ctx extends ContextValues>(opts: ContextValueOpts<Ctx, Seed, Src, Seed>): Seed | null | undefined {
+  grow(opts: ContextValueOpts<Seed, Src, Seed>): Seed | null | undefined {
 
     const { seeder, seed } = opts;
 

--- a/src/context-key.ts
+++ b/src/context-key.ts
@@ -60,12 +60,9 @@ export abstract class ContextKey<Value, Src = Value, Seed = unknown> implements 
   /**
    * Grows context value out of its seed.
    *
-   * @typeparam Ctx  Context type.
-   * @param opts  Context value growth options.
-   *
-   * @returns Single context value, or `undefined` if there is no default value.
+   * @param slot  Context value slot to insert the value to.
    */
-  abstract grow(opts: ContextValueOpts<Value, Src, Seed>): Value | null | undefined;
+  abstract grow(slot: ContextValueSlot<Value, Src, Seed>): void;
 
   toString(): string {
     return `ContextKey(${this.name})`;
@@ -74,47 +71,132 @@ export abstract class ContextKey<Value, Src = Value, Seed = unknown> implements 
 }
 
 /**
- * Context value growth options.
+ * Context value slot to put the grown value into.
  *
- * An instance of these options is passed to [[ContextKey.grow]] method to provide the necessary value growth context.
+ * An instance of the value slot is passed to [[ContextKey.grow]] method to provide the necessary context and optionally
+ * accept a new value.
  *
  * @typeparam Value  Context value type.
  * @typeparam Src  Source value type.
  * @typeparam Seed  Value seed type.
  */
-export interface ContextValueOpts<Value, Src, Seed> {
+export type ContextValueSlot<Value, Src, Seed> =
+    | ContextValueSlot.WithFallback<Value, Src, Seed>
+    | ContextValueSlot.WithoutFallback<Value, Src, Seed>;
+
+export namespace ContextValueSlot {
 
   /**
-   * Target context.
-   */
-  readonly context: ContextValues;
-
-  /**
-   * Context value seeder.
-   */
-  readonly seeder: ContextSeeder<ContextValues, Src, Seed>;
-
-  /**
-   * Context value seed.
-   */
-  readonly seed: Seed;
-
-  /**
-   * A fallback value to use if there is no value associated with the given key.
+   * Base context value slot interface.
    *
-   * Can be `null` or `undefined`.
+   * @typeparam Value  Context value type.
+   * @typeparam Src  Source value type.
+   * @typeparam Seed  Value seed type.
    */
-  readonly or?: Value | null;
+  export interface Base<Value, Src, Seed> {
+
+    /**
+     * Target context.
+     */
+    readonly context: ContextValues;
+
+    /**
+     * A key to associated value with.
+     */
+    readonly key: ContextKey<Value, Src, Seed>;
+
+    /**
+     * Context value seeder.
+     */
+    readonly seeder: ContextSeeder<ContextValues, Src, Seed>;
+
+    /**
+     * Context value seed.
+     */
+    readonly seed: Seed;
+
+    /**
+     * Whether a {@link ContextRequest.Opts.or fallback} value has been specified.
+     */
+    readonly hasFallback: boolean;
+
+    /**
+     * A {@link ContextRequest.Opts.or fallback} value that will be used unless another one {@link insert inserted} into
+     * this slot.
+     *
+     * Can be `null` or `undefined`.
+     *
+     * Always `undefined` when {@link hasFallback there is no fallback}.
+     */
+    readonly or: Value | null | undefined;
+
+    /**
+     * Insert the value into the slot.
+     *
+     * The value will be associated with key after [[ContextKey.grow]] method exit.
+     *
+     * Supersedes a previously inserted value.
+     *
+     * @param value  A value to associate with the key, or `null`/`undefined` to not associate any value.
+     */
+    insert(value: Value | null | undefined): void;
+
+    /**
+     * Fills this slot by the given function.
+     *
+     * @param grow  A function accepting a value slot as its only parameter.
+     *
+     * @returns A value associated with target key by the given function, or `null`/`undefined` when no value
+     * associated.
+     */
+    fillBy(grow: (this: void, slot: ContextValueSlot<Value, Src, Seed>) => void): Value | null | undefined;
+
+  }
 
   /**
-   * Handles missing context value.
+   * Base context value slot with fallback value.
    *
-   * It can be called to prefer a fallback value over the default one specified in the value key.
-   *
-   * @param defaultProvider  Default value provider. It is called unless a fallback value is specified.
-   * If it returns a non-null/non-undefined value, then the returned value will be associated with the context key.
+   * @typeparam Value  Context value type.
+   * @typeparam Src  Source value type.
+   * @typeparam Seed  Value seed type.
    */
-  byDefault(defaultProvider: () => Value | null | undefined): Value | null | undefined;
+  export interface WithFallback<Value, Src, Seed> extends Base<Value, Src, Seed> {
+
+    /**
+     * Whether a {@link ContextRequest.Opts.or fallback} value has been specified.
+     *
+     * Always `true`
+     */
+    readonly hasFallback: true;
+
+    /**
+     * A {@link ContextRequest.Opts.or fallback} value that will be used unless another one {@link insert inserted} into
+     * this slot.
+     *
+     * Can be `null` or `undefined`.
+     */
+    readonly or: Value | null | undefined;
+
+  }
+
+  export interface WithoutFallback<Value, Src, Seed> extends Base<Value, Src, Seed> {
+
+    /**
+     * Whether a {@link ContextRequest.Opts.or fallback} value has been specified.
+     *
+     * Always `false`
+     */
+    readonly hasFallback: false;
+
+    /**
+     * A {@link ContextRequest.Opts.or fallback} value that will be used unless another one {@link insert inserted} into
+     * this slot.
+     *
+     * Always `undefined`.
+     */
+    readonly or: undefined;
+
+  }
 
 }
 
@@ -169,11 +251,15 @@ export abstract class ContextSeedKey<Src, Seed> extends ContextKey<Seed, Src, Se
    */
   abstract seeder<Ctx extends ContextValues>(): ContextSeeder<Ctx, Src, Seed>;
 
-  grow(opts: ContextValueOpts<Seed, Src, Seed>): Seed | null | undefined {
+  grow(opts: ContextValueSlot<Seed, Src, Seed>): void {
 
     const { seeder, seed } = opts;
 
-    return seeder.isEmpty(seed) ? opts.byDefault(() => seed) : seed;
+    if (!seeder.isEmpty(seed)) {
+      opts.insert(seed);
+    } else if (!opts.hasFallback) {
+      opts.insert(seed);
+    }
   }
 
 }

--- a/src/context-key.ts
+++ b/src/context-key.ts
@@ -3,6 +3,7 @@
  * @module @proc7ts/context-values
  */
 import { ContextRef } from './context-ref';
+import { ContextRegistry } from './context-registry';
 import { ContextSeeder } from './context-seeder';
 import { ContextValues } from './context-values';
 
@@ -151,6 +152,15 @@ export namespace ContextValueSlot {
      */
     fillBy(grow: (this: void, slot: ContextValueSlot<Value, Src, Seed>) => void): Value | null | undefined;
 
+    /**
+     * Registers a setup procedure issued when context value associated with target key.
+     *
+     * Setup will be issued at most once per context. Setup won't be issued if no value {@link insert inserted}.
+     *
+     * @param setup  Context value setup procedure.
+     */
+    setup(setup: ContextValueSetup<Value, Src, Seed>): void;
+
   }
 
   /**
@@ -199,6 +209,32 @@ export namespace ContextValueSlot {
   }
 
 }
+
+/**
+ * Context value setup procedure signature.
+ *
+ * A function with this signature can be passed to {@link ContextValueSlot.Base.setup} method to be issued when
+ * the value associated with target key.
+ */
+export type ContextValueSetup<Value, Src, Seed> =
+/**
+ * @param key  A key the value associated with.
+ * @param context  Target context the value associated with.
+ * @param registry  A registry of context value providers. This context is shared among all contexts
+ * {@link ContextRegistry.newValues created} by it.
+ */
+    (
+        this: void,
+        {
+          key,
+          context,
+          registry,
+        }: {
+          key: ContextKey<Value, Src, Seed>;
+          context: ContextValues;
+          registry: ContextRegistry;
+        }
+    ) => void;
 
 /**
  * A provider of default value of context key.

--- a/src/context-ref.ts
+++ b/src/context-ref.ts
@@ -35,9 +35,11 @@ export namespace ContextRequest {
   export interface Opts<Value> {
 
     /**
-     * A fallback value that will be returned if there is no value associated with the given key.
+     * A fallback value that will be returned if there is no value associated with target key.
      *
      * Can be `null` or `undefined`.
+     *
+     * This property will be accessed only if there is no value associated with target key.
      */
     or?: Value | null;
 

--- a/src/context-registry.ts
+++ b/src/context-registry.ts
@@ -176,7 +176,7 @@ export class ContextRegistry<Ctx extends ContextValues = ContextValues> {
       let defaultUsed = false;
 
       const valueOpts: {
-        -readonly [K in keyof ContextValueOpts<Ctx, Value, Src, Seed>]: ContextValueOpts<Ctx, Value, Src, Seed>[K];
+        -readonly [K in keyof ContextValueOpts<Value, Src, Seed>]: ContextValueOpts<Value, Src, Seed>[K];
       } = {
         context,
         seeder,

--- a/src/iterative-context-key.ts
+++ b/src/iterative-context-key.ts
@@ -76,7 +76,14 @@ export abstract class IterativeContextKey<Value, Src = Value> extends ContextKey
    * @param name  Human-readable key name.
    * @param seedKey  Value seed key. A new one will be constructed when omitted.
    */
-  constructor(name: string, seedKey?: ContextSeedKey<Src, Iterable<Src>>) {
+  constructor(
+      name: string,
+      {
+        seedKey,
+      }: {
+        seedKey?: ContextSeedKey<Src, Iterable<Src>>;
+      } = {},
+  ) {
     super(name);
     this.seedKey = seedKey || new IterativeSeedKey(this);
   }

--- a/src/multi-context-key.ts
+++ b/src/multi-context-key.ts
@@ -5,7 +5,6 @@
 import { valuesProvider } from '@proc7ts/call-thru';
 import { ContextKey, ContextKeyDefault, ContextSeedKey, ContextValueOpts } from './context-key';
 import { ContextRef } from './context-ref';
-import { ContextValues } from './context-values';
 import { IterativeContextKey } from './iterative-context-key';
 
 /**
@@ -56,8 +55,8 @@ export class MultiContextKey<Src>
     this.byDefault = byDefault;
   }
 
-  grow<Ctx extends ContextValues>(
-      opts: ContextValueOpts<Ctx, readonly Src[], Src, Iterable<Src>>,
+  grow(
+      opts: ContextValueOpts<readonly Src[], Src, Iterable<Src>>,
   ): readonly Src[] | null | undefined {
 
     const result = Array.from(opts.seed);

--- a/src/multi-context-key.ts
+++ b/src/multi-context-key.ts
@@ -3,7 +3,7 @@
  * @module @proc7ts/context-values
  */
 import { valuesProvider } from '@proc7ts/call-thru';
-import { ContextKey, ContextKeyDefault, ContextSeedKey, ContextValueOpts } from './context-key';
+import { ContextKey, ContextKeyDefault, ContextSeedKey, ContextValueSlot } from './context-key';
 import { ContextRef } from './context-ref';
 import { IterativeContextKey } from './iterative-context-key';
 
@@ -56,25 +56,21 @@ export class MultiContextKey<Src>
   }
 
   grow(
-      opts: ContextValueOpts<readonly Src[], Src, Iterable<Src>>,
-  ): readonly Src[] | null | undefined {
+      slot: ContextValueSlot<readonly Src[], Src, Iterable<Src>>,
+  ): void {
 
-    const result = Array.from(opts.seed);
+    const result = Array.from(slot.seed);
 
     if (result.length) {
-      return result;
-    }
+      slot.insert(result);
+    } else if (!slot.hasFallback) {
 
-    return opts.byDefault(() => {
-
-      const defaultSources = this.byDefault(opts.context, this);
+      const defaultSources = this.byDefault(slot.context, this);
 
       if (defaultSources) {
-        return Array.from(defaultSources);
+        slot.insert(Array.from(defaultSources));
       }
-
-      return;
-    });
+    }
   }
 
 }

--- a/src/simple-context-key.ts
+++ b/src/simple-context-key.ts
@@ -122,7 +122,14 @@ export abstract class SimpleContextKey<Value, Src = Value> extends ContextKey<Va
    * @param name  Human-readable key name.
    * @param seedKey  Value seed key. A new one will be constructed when omitted.
    */
-  constructor(name: string, seedKey?: ContextSeedKey<Src, SimpleContextKey.Seed<Src>>) {
+  constructor(
+      name: string,
+      {
+        seedKey,
+      }: {
+        seedKey?: ContextSeedKey<Src, SimpleContextKey.Seed<Src>>;
+      } = {},
+  ) {
     super(name);
     this.seedKey = seedKey || new SimpleSeedKey(this);
   }

--- a/src/single-context-key.ts
+++ b/src/single-context-key.ts
@@ -3,7 +3,7 @@
  * @module @proc7ts/context-values
  */
 import { noop } from '@proc7ts/call-thru';
-import { ContextKey, ContextKeyDefault, ContextSeedKey, ContextValueOpts } from './context-key';
+import { ContextKey, ContextKeyDefault, ContextSeedKey, ContextValueSlot } from './context-key';
 import { ContextRef } from './context-ref';
 import { SimpleContextKey } from './simple-context-key';
 
@@ -48,21 +48,21 @@ export class SingleContextKey<Value>
         byDefault?: ContextKeyDefault<Value, ContextKey<Value>>;
       } = {},
   ) {
-    super(name, seedKey);
+    super(name, { seedKey });
     this.byDefault = byDefault;
   }
 
   grow(
-      opts: ContextValueOpts<Value, Value, SimpleContextKey.Seed<Value>>,
-  ): Value | null | undefined {
+      slot: ContextValueSlot<Value, Value, SimpleContextKey.Seed<Value>>,
+  ): void {
 
-    const value = opts.seed();
+    const value = slot.seed();
 
     if (value != null) {
-      return value;
+      slot.insert(value);
+    } else if (!slot.hasFallback) {
+      slot.insert(this.byDefault(slot.context, this));
     }
-
-    return opts.byDefault(() => this.byDefault(opts.context, this));
   }
 
 }

--- a/src/single-context-key.ts
+++ b/src/single-context-key.ts
@@ -5,7 +5,6 @@
 import { noop } from '@proc7ts/call-thru';
 import { ContextKey, ContextKeyDefault, ContextSeedKey, ContextValueOpts } from './context-key';
 import { ContextRef } from './context-ref';
-import { ContextValues } from './context-values';
 import { SimpleContextKey } from './simple-context-key';
 
 /**
@@ -53,8 +52,8 @@ export class SingleContextKey<Value>
     this.byDefault = byDefault;
   }
 
-  grow<Ctx extends ContextValues>(
-      opts: ContextValueOpts<Ctx, Value, Value, SimpleContextKey.Seed<Value>>,
+  grow(
+      opts: ContextValueOpts<Value, Value, SimpleContextKey.Seed<Value>>,
   ): Value | null | undefined {
 
     const value = opts.seed();

--- a/src/updatable/context-supply.ts
+++ b/src/updatable/context-supply.ts
@@ -2,9 +2,8 @@
  * @packageDocumentation
  * @module @proc7ts/context-values/updatable
  */
-import { noop } from '@proc7ts/call-thru';
 import { EventSupply, EventSupply__symbol, EventSupplyPeer } from '@proc7ts/fun-events';
-import { ContextValueOpts } from '../context-key';
+import { ContextValueSlot } from '../context-key';
 import { ContextRef } from '../context-ref';
 import { SimpleContextKey } from '../simple-context-key';
 
@@ -27,12 +26,13 @@ class ContextSupplyKey extends SimpleContextKey<ContextSupply> {
   }
 
   grow(
-      opts: ContextValueOpts<ContextSupply, ContextSupply, SimpleContextKey.Seed<ContextSupply>>,
-  ): ContextSupply | null | undefined {
-    return opts.seed()
-        || opts.or
-        || (opts.context as Partial<EventSupplyPeer>)[EventSupply__symbol]
-        || opts.byDefault(noop);
+      slot: ContextValueSlot<ContextSupply, ContextSupply, SimpleContextKey.Seed<ContextSupply>>,
+  ): void {
+    slot.insert(
+        slot.seed()
+        || (slot.hasFallback ? slot.or : null)
+        || (slot.context as Partial<EventSupplyPeer>)[EventSupply__symbol],
+    );
   }
 
 }

--- a/src/updatable/context-supply.ts
+++ b/src/updatable/context-supply.ts
@@ -6,7 +6,6 @@ import { noop } from '@proc7ts/call-thru';
 import { EventSupply, EventSupply__symbol, EventSupplyPeer } from '@proc7ts/fun-events';
 import { ContextValueOpts } from '../context-key';
 import { ContextRef } from '../context-ref';
-import { ContextValues } from '../context-values';
 import { SimpleContextKey } from '../simple-context-key';
 
 /**
@@ -27,8 +26,8 @@ class ContextSupplyKey extends SimpleContextKey<ContextSupply> {
     super('context-supply');
   }
 
-  grow<Ctx extends ContextValues>(
-      opts: ContextValueOpts<Ctx, ContextSupply, ContextSupply, SimpleContextKey.Seed<ContextSupply>>,
+  grow(
+      opts: ContextValueOpts<ContextSupply, ContextSupply, SimpleContextKey.Seed<ContextSupply>>,
   ): ContextSupply | null | undefined {
     return opts.seed()
         || opts.or

--- a/src/updatable/context-up-key.spec.ts
+++ b/src/updatable/context-up-key.spec.ts
@@ -1,0 +1,49 @@
+import { nextArgs, noop } from '@proc7ts/call-thru';
+import { AfterEvent, afterEventBy, EventKeeper, nextAfterEvent } from '@proc7ts/fun-events';
+import { ContextValueSlot } from '../context-key';
+import { ContextKeyError } from '../context-key-error';
+import { ContextRegistry } from '../context-registry';
+import { ContextUpKey } from './context-up-key';
+
+describe('ContextUpKey', () => {
+  describe('createUpKey', () => {
+    it('throws when no value', () => {
+
+      class TestKey extends ContextUpKey<AfterEvent<string[]>, string> {
+
+        readonly upKey: ContextUpKey.UpKey<string, string>;
+
+        constructor() {
+          super('test-key');
+          this.upKey = this.createUpKey(noop);
+        }
+
+        grow(slot: ContextValueSlot<AfterEvent<string[]>, EventKeeper<string[]> | string, AfterEvent<string[]>>): void {
+
+          const value = slot.seed.keepThru((...sources: string[]) => {
+            if (sources.length) {
+              // Sources present. Use them.
+              return nextArgs(...sources);
+            }
+            if (slot.hasFallback && slot.or) {
+              return nextAfterEvent(slot.or); // Backup value found.
+            }
+
+            // Backup value is absent. Construct an error response.
+            return nextAfterEvent(afterEventBy<string[]>(() => {
+              throw new ContextKeyError(this);
+            }));
+          });
+
+          slot.insert(value);
+        }
+
+      }
+
+      const key = new TestKey();
+      const values = new ContextRegistry().newValues();
+
+      expect(() => values.get(key.upKey).to(noop)).toThrow(ContextKeyError);
+    });
+  });
+});

--- a/src/updatable/context-up-key.ts
+++ b/src/updatable/context-up-key.ts
@@ -143,8 +143,8 @@ export interface ContextUpRef<Value, Src> extends ContextRef<Value, Src | EventK
 class ContextUpKeyUpKey<Value, Src>
     extends ContextKey<ContextUpKey.Up<Value>, Src | EventKeeper<Src[]>, AfterEvent<Src[]>> {
 
-  readonly grow: <Ctx extends ContextValues>(
-      opts: ContextValueOpts<Ctx, ContextUpKey.Up<Value>, EventKeeper<Src[]> | Src, AfterEvent<Src[]>>,
+  readonly grow: (
+      opts: ContextValueOpts<ContextUpKey.Up<Value>, EventKeeper<Src[]> | Src, AfterEvent<Src[]>>,
   ) => ContextUpKey.Up<Value>;
 
   get seedKey(): ContextSeedKey<Src | EventKeeper<Src[]>, AfterEvent<Src[]>> {
@@ -153,8 +153,8 @@ class ContextUpKeyUpKey<Value, Src>
 
   constructor(
       private readonly _key: ContextUpKey<Value, Src>,
-      grow: <Ctx extends ContextValues>(
-          opts: ContextValueOpts<Ctx, ContextUpKey.Up<Value>, EventKeeper<Src[]> | Src, AfterEvent<Src[]>>,
+      grow: (
+          opts: ContextValueOpts<ContextUpKey.Up<Value>, EventKeeper<Src[]> | Src, AfterEvent<Src[]>>,
       ) => ContextUpKey.Up<Value>,
   ) {
     super(_key.name + ':up');
@@ -213,8 +213,8 @@ export abstract class ContextUpKey<Value, Src>
    * @returns New updates keeper key.
    */
   protected createUpKey(
-      grow: <Ctx extends ContextValues>(
-          opts: ContextValueOpts<Ctx, ContextUpKey.Up<Value>, EventKeeper<Src[]> | Src, AfterEvent<Src[]>>,
+      grow: (
+          opts: ContextValueOpts<ContextUpKey.Up<Value>, EventKeeper<Src[]> | Src, AfterEvent<Src[]>>,
       ) => ContextUpKey.Up<Value>,
   ): ContextUpKey.UpKey<Value, Src> {
     return new ContextUpKeyUpKey(this, grow);

--- a/src/updatable/fn-context-key.ts
+++ b/src/updatable/fn-context-key.ts
@@ -84,9 +84,8 @@ export class FnContextKey<Args extends any[], Ret = void>
     );
   }
 
-  grow<Ctx extends ContextValues>(
+  grow(
       opts: ContextValueOpts<
-          Ctx,
           (this: void, ...args: Args) => Ret,
           EventKeeper<((this: void, ...args: Args) => Ret)[]> | ((this: void, ...args: Args) => Ret),
           AfterEvent<((this: void, ...args: Args) => Ret)[]>>,

--- a/src/updatable/fn-context-key.ts
+++ b/src/updatable/fn-context-key.ts
@@ -4,7 +4,7 @@
  */
 import { noop } from '@proc7ts/call-thru';
 import { AfterEvent, afterThe, EventKeeper, nextAfterEvent } from '@proc7ts/fun-events';
-import { ContextKeyDefault, ContextValueOpts } from '../context-key';
+import { ContextKeyDefault, ContextValueSlot } from '../context-key';
 import { ContextKeyError } from '../context-key-error';
 import { ContextValues } from '../context-values';
 import { contextDestroyed } from './context-destroyed';
@@ -67,42 +67,43 @@ export class FnContextKey<Args extends any[], Ret = void>
     super(name, seedKey);
     this.byDefault = (context, key) => byDefault(context, key) || (() => { throw new ContextKeyError(this); });
     this.upKey = this.createUpKey(
-        opts => opts.seed.keepThru(
-            (...fns) => {
-              if (fns.length) {
-                return fns[fns.length - 1];
-              }
+        slot => {
+          slot.insert(slot.seed.keepThru(
+              (...fns) => {
+                if (fns.length) {
+                  return fns[fns.length - 1];
+                }
 
-              const defaultProvider = (): AfterEvent<[(this: void, ...args: Args) => Ret]> => afterThe(this.byDefault(
-                  opts.context,
-                  this,
-              ));
+                if (slot.hasFallback && slot.or) {
+                  return nextAfterEvent(slot.or);
+                }
 
-              return nextAfterEvent(opts.byDefault(defaultProvider) || defaultProvider());
-            },
-        ),
+                return nextAfterEvent(afterThe(this.byDefault(slot.context, this)));
+              },
+          ));
+        },
     );
   }
 
   grow(
-      opts: ContextValueOpts<
+      slot: ContextValueSlot<
           (this: void, ...args: Args) => Ret,
           EventKeeper<((this: void, ...args: Args) => Ret)[]> | ((this: void, ...args: Args) => Ret),
           AfterEvent<((this: void, ...args: Args) => Ret)[]>>,
-  ): (this: void, ...args: Args) => Ret {
+  ): void {
 
     let delegated: (this: void, ...args: Args) => Ret;
 
-    opts.context.get(
+    slot.context.get(
         this.upKey,
-        'or' in opts ? { or: opts.or != null ? afterThe(opts.or) : opts.or } : undefined,
+        slot.hasFallback ? { or: slot.or != null ? afterThe(slot.or) : slot.or } : undefined,
     )!.to(
         fn => delegated = fn,
     ).whenOff(
         reason => delegated = contextDestroyed(reason),
     );
 
-    return (...args) => delegated(...args);
+    slot.insert((...args) => delegated(...args));
   }
 
 }

--- a/src/updatable/multi-context-up-key.ts
+++ b/src/updatable/multi-context-up-key.ts
@@ -6,7 +6,6 @@ import { nextArgs, noop } from '@proc7ts/call-thru';
 import { AfterEvent, afterEventBy, afterThe, EventKeeper, nextAfterEvent } from '@proc7ts/fun-events';
 import { ContextKeyDefault, ContextValueOpts } from '../context-key';
 import { ContextKeyError } from '../context-key-error';
-import { ContextValues } from '../context-values';
 import { ContextSupply } from './context-supply';
 import { ContextUpKey, ContextUpRef } from './context-up-key';
 
@@ -63,8 +62,8 @@ export class MultiContextUpKey<Src>
     this.byDefault = byDefault;
   }
 
-  grow<Ctx extends ContextValues>(
-      opts: ContextValueOpts<Ctx, AfterEvent<Src[]>, EventKeeper<Src[]> | Src, AfterEvent<Src[]>>,
+  grow(
+      opts: ContextValueOpts<AfterEvent<Src[]>, EventKeeper<Src[]> | Src, AfterEvent<Src[]>>,
   ): AfterEvent<Src[]> {
 
     const value = opts.seed.keepThru((...sources) => {

--- a/src/updatable/single-context-up-key.ts
+++ b/src/updatable/single-context-up-key.ts
@@ -6,7 +6,6 @@ import { nextArg, noop } from '@proc7ts/call-thru';
 import { AfterEvent, afterEventBy, afterThe, EventKeeper, nextAfterEvent } from '@proc7ts/fun-events';
 import { ContextKeyDefault, ContextValueOpts } from '../context-key';
 import { ContextKeyError } from '../context-key-error';
-import { ContextValues } from '../context-values';
 import { ContextSupply } from './context-supply';
 import { ContextUpKey, ContextUpRef } from './context-up-key';
 
@@ -63,8 +62,8 @@ export class SingleContextUpKey<Value>
     this.byDefault = byDefault;
   }
 
-  grow<Ctx extends ContextValues>(
-      opts: ContextValueOpts<Ctx, AfterEvent<[Value]>, EventKeeper<Value[]> | Value, AfterEvent<Value[]>>,
+  grow(
+      opts: ContextValueOpts<AfterEvent<[Value]>, EventKeeper<Value[]> | Value, AfterEvent<Value[]>>,
   ): AfterEvent<[Value]> {
 
     const value = opts.seed.keepThru((...sources: Value[]) => {


### PR DESCRIPTION
- Change context value construction API:
  Use `ContextValueSlot` to insert constructed value instead of returning it from
  `ContextKey.grow()` method.
- Add support for context value setup.
  The setup procedure is issued right after the context value is associated with the key.