### PR TITLE
Contextual value references

### DIFF
--- a/src/conventional/apply-context-to.spec.ts
+++ b/src/conventional/apply-context-to.spec.ts
@@ -1,0 +1,36 @@
+import type { ContextRef } from '../context-ref';
+import type { ContextValues } from '../context-values';
+import { ContextRegistry } from '../registry';
+import { SingleContextKey } from '../singleton';
+import { applyContextTo } from './apply-context-to';
+import { Contextual__symbol } from './contextual';
+
+describe('applyContextTo', () => {
+
+  let registry: ContextRegistry;
+  let context: ContextValues;
+
+  beforeEach(() => {
+    registry = new ContextRegistry();
+    context = registry.newValues();
+  });
+
+  let key: ContextRef<string>;
+
+  beforeAll(() => {
+    key = new SingleContextKey<string>('test-key');
+  });
+
+  it('converts bare value to its provider', () => {
+    registry.provide({ a: key, by: applyContextTo('test') });
+    expect(context.get(key)).toBe('test');
+  });
+  it('converts `null` value to noop provider', () => {
+    registry.provide({ a: key, by: applyContextTo(null) });
+    expect(context.get(key, { or: 'fallback' })).toBe('fallback');
+  });
+  it('converts contextual value to its resolver', () => {
+    registry.provide({ a: key, by: applyContextTo({ [Contextual__symbol]: () => 'test' }) });
+    expect(context.get(key)).toBe('test');
+  });
+});

--- a/src/conventional/apply-context-to.ts
+++ b/src/conventional/apply-context-to.ts
@@ -1,0 +1,24 @@
+import { valueProvider } from '@proc7ts/primitives';
+import type { ContextValues } from '../context-values';
+import type { ContextValueProvider } from '../registry';
+import type { Contextual } from './contextual';
+import { Contextual__symbol, isContextual } from './contextual';
+
+/**
+ * Converts a value or its {@link Contextual contextual reference} to context value {@link ContextValueProvider
+ * provider}.
+ *
+ * @typeParam T - Value type.
+ * @typeParam TCtx - Supported context type.
+ * @param value - A value to convert. May be either a bare value, its contextual reference, or `null`/`undefined` to
+ * provide nothing.
+ *
+ * @returns Context value provider.
+ */
+export function applyContextTo<T, TCtx extends ContextValues = ContextValues>(
+    value: Contextual<T, TCtx> | T | null | undefined,
+): ContextValueProvider<T, TCtx> {
+  return isContextual(value)
+      ? context => value[Contextual__symbol](context)
+      : valueProvider(value);
+}

--- a/src/conventional/contextual.spec.ts
+++ b/src/conventional/contextual.spec.ts
@@ -1,0 +1,26 @@
+import { noop } from '@proc7ts/primitives';
+import { Contextual, Contextual__symbol, isContextual } from './contextual';
+
+describe('isContextual', () => {
+  it('returns `true` for contextual reference', () => {
+    expect(isContextual({ [Contextual__symbol]: noop })).toBe(true);
+  });
+  it('returns `true` for functional contextual reference', () => {
+
+    const contextual = ((): number => 1) as unknown as Contextual<number>;
+
+    contextual[Contextual__symbol] = noop;
+
+    expect(isContextual({ [Contextual__symbol]: noop })).toBe(true);
+  });
+  it('returns `false` for `null` value', () => {
+    expect(isContextual(null)).toBe(false);
+  });
+  it('returns `false` for non-object value', () => {
+    expect(isContextual(1)).toBe(false);
+    expect(isContextual('foo')).toBe(false);
+  });
+  it('returns `false` if `[Contextual__symbol]` is not a method', () => {
+    expect(isContextual({ [Contextual__symbol]: 1 })).toBe(false);
+  });
+});

--- a/src/conventional/contextual.ts
+++ b/src/conventional/contextual.ts
@@ -1,0 +1,43 @@
+import type { ContextValues } from '../context-values';
+
+/**
+ * A key of {@link Contextual contextual value reference} method resolving a contextual instance.
+ */
+export const Contextual__symbol = (/*#__PURE__*/ Symbol('Contextual'));
+
+/**
+ * Contextual value reference.
+ *
+ * @typeParam T - Referred contextual instance type.
+ * @typeParam TCtx - Supported context type.
+ */
+export interface Contextual<T, TCtx extends ContextValues = ContextValues> {
+
+  /**
+   * Resolves a contextual instance for the target context.
+   *
+   * @param context - Target context.
+   *
+   * @returns Either contextual instance, or `null`/`undefined` when not resolved.
+   */
+  [Contextual__symbol](context: TCtx): T | null | undefined;
+
+}
+
+/**
+ * Checks whether the given value is a {@link Contextual contextual reference}.
+ *
+ * @typeParam T - Expected referred contextual instance type.
+ * @typeParam TCtx - Expected context type.
+ * @typeParam TOther - Another type the value may have.
+ * @param value - A value to check.
+ *
+ * @returns `true` if the given `value` has a {@link Contextual__symbol} method, or `false` otherwise.
+ */
+export function isContextual<T, TCtx extends ContextValues = ContextValues, TOther = unknown>(
+    value: Contextual<T, TCtx> | TOther,
+): value is Contextual<T, TCtx> {
+  return !!value
+      && (typeof value === 'object' || typeof value === 'function')
+      && typeof (value as Partial<Contextual<T, TCtx>>)[Contextual__symbol] === 'function';
+}

--- a/src/conventional/index.ts
+++ b/src/conventional/index.ts
@@ -1,1 +1,2 @@
 export * from './context-supply';
+export * from './contextual';

--- a/src/conventional/index.ts
+++ b/src/conventional/index.ts
@@ -1,2 +1,3 @@
+export * from './apply-context-to';
 export * from './context-supply';
 export * from './contextual';

--- a/src/key/context-seeder.ts
+++ b/src/key/context-seeder.ts
@@ -22,7 +22,7 @@ export interface ContextSeeder<TCtx extends ContextValues, TSrc, TSeed> {
    *
    * @returns Provider supply instance that removes just added context value provider once cut off.
    */
-  provide(provider: ContextValueProvider<TCtx, TSrc>): Supply;
+  provide(provider: ContextValueProvider<TSrc, TCtx>): Supply;
 
   /**
    * Creates context value seed for target `context`.

--- a/src/registry/context-registry.ts
+++ b/src/registry/context-registry.ts
@@ -37,20 +37,19 @@ export class ContextRegistry<TCtx extends ContextValues = ContextValues> {
   /**
    * Provides context value.
    *
-   * @typeParam TDeps - Dependencies tuple type.
    * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
+   * @typeParam TDeps - Dependencies tuple type.
    * @param spec - Context value specifier.
    *
    * @returns Provider supply instance that removes just added context value provider once cut off.
    */
-  provide<TDeps extends any[], TSrc, TSeed>(spec: ContextValueSpec<TCtx, unknown, TDeps, TSrc, TSeed>): Supply {
+  provide<TSrc, TDeps extends any[]>(spec: ContextValueSpec<TCtx, unknown, TSrc, TDeps>): Supply {
     if (isContextBuilder(spec)) {
       return spec[ContextBuilder__symbol](this);
     }
 
     const { a: { [ContextKey__symbol]: { seedKey } }, by } = contextValueSpec(spec);
-    const [seeder] = this._seeders.issuer<TSrc, TSeed>(seedKey);
+    const [seeder] = this._seeders.issuer(seedKey);
 
     return seeder.provide(by);
   }
@@ -125,8 +124,8 @@ export class ContextRegistry<TCtx extends ContextValues = ContextValues> {
 /**
  * @internal
  */
-function isContextBuilder<TCtx extends ContextValues, TValue, TDeps extends any[], TSrc, TSeed>(
-    spec: ContextValueSpec<TCtx, TValue, TDeps, TSrc, TSeed>,
+function isContextBuilder<TCtx extends ContextValues, TValue, TSrc, TDeps extends any[]>(
+    spec: ContextValueSpec<TCtx, TValue, TSrc, TDeps>,
 ): spec is ContextBuilder<TCtx> {
   return typeof (spec as Partial<ContextBuilder<TCtx>>)[ContextBuilder__symbol] === 'function';
 }

--- a/src/registry/context-value-provider.ts
+++ b/src/registry/context-value-provider.ts
@@ -1,0 +1,18 @@
+import type { ContextValues } from '../context-values';
+
+/**
+ * Context value provider.
+ *
+ * When used to provide a value associated with particular context key, it provides a source value rather a context
+ * value itself.
+ *
+ * @typeParam T - Provided value type.
+ * @typeParam TCtx - Supported context type.
+ */
+export type ContextValueProvider<T, TCtx extends ContextValues = ContextValues> =
+/**
+ * @param context - Target context.
+ *
+ * @return Either provided value, or `null`/`undefined` when unknown.
+ */
+    (this: void, context: TCtx) => T | null | undefined;

--- a/src/registry/context-value-spec.spec.ts
+++ b/src/registry/context-value-spec.spec.ts
@@ -63,7 +63,7 @@ describe('contextValueSpec', () => {
 
     const key1 = new SingleContextKey<string>('arg1');
     const key2 = new SingleContextKey<number>('arg2');
-    const spec: ContextValueSpec.ByProviderWithDeps<[string, number], string> = {
+    const spec: ContextValueSpec.ByProviderWithDeps<string, [string, number]> = {
       a: new SingleContextKey<string>('value'),
       by(first: string, second: number) {
         return `${first}.${second}`;
@@ -157,7 +157,7 @@ describe('contextValueSpec', () => {
 
       const key1 = new SingleContextKey<string>('arg1');
       const key2 = new SingleContextKey<number>('arg2');
-      const spec: ContextValueSpec.AsInstanceWithDeps<[string, number], Value> = {
+      const spec: ContextValueSpec.AsInstanceWithDeps<Value, [string, number]> = {
         a: Value,
         as: Val,
         with: [key1, key2],
@@ -192,7 +192,7 @@ describe('contextValueSpec', () => {
 
       const key1 = new SingleContextKey<string>('arg1');
       const key2 = new SingleContextKey<number>('arg2');
-      const spec: ContextValueSpec.SelfInstanceWithDeps<[string, number], Value> = {
+      const spec: ContextValueSpec.SelfInstanceWithDeps<Value, [string, number]> = {
         as: Value,
         with: [key1, key2],
       };

--- a/src/registry/context-value-spec.ts
+++ b/src/registry/context-value-spec.ts
@@ -12,17 +12,15 @@ import type { ContextValueProvider } from './context-value-provider';
  *
  * @typeParam TCtx - Context type.
  * @typeParam TValue - Context value type.
- * @typeParam TDeps - Dependencies tuple type.
  * @typeParam TSrc - Source value type.
- * @typeParam TSeed - Value seed type.
+ * @typeParam TDeps - Dependencies tuple type.
  */
 export type ContextValueSpec<
     TCtx extends ContextValues,
     TValue,
-    TDeps extends any[] = unknown[],
     TSrc = TValue,
-    TSeed = unknown> =
-    | ContextValueSpec.Explicit<TCtx, TValue, TDeps, TSrc, TSeed>
+    TDeps extends any[] = unknown[]> =
+    | ContextValueSpec.Explicit<TCtx, TValue, TSrc, TDeps>
     | ContextBuilder<TCtx>;
 
 export namespace ContextValueSpec {
@@ -32,37 +30,34 @@ export namespace ContextValueSpec {
    *
    * @typeParam TCtx - Context type.
    * @typeParam TValue - Context value type.
-   * @typeParam TDeps - Dependencies tuple type.
    * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
+   * @typeParam TDeps - Dependencies tuple type.
    */
   export type Explicit<
       TCtx extends ContextValues,
       TValue,
-      TDeps extends any[] = unknown[],
       TSrc = TValue,
-      TSeed = unknown> =
-      | ContextValueSpec.IsConstant<TSrc, TSeed>
-      | ContextValueSpec.ViaAlias<TSrc, TSeed>
-      | ContextValueSpec.ByProvider<TCtx, TSrc, TSeed>
-      | ContextValueSpec.ByProviderWithDeps<TDeps, TSrc, TSeed>
-      | ContextValueSpec.AsInstance<TCtx, TSrc, TSeed>
-      | ContextValueSpec.SelfInstance<TCtx, TSrc, TSeed>
-      | ContextValueSpec.AsInstanceWithDeps<TDeps, TSrc, TSeed>
-      | ContextValueSpec.SelfInstanceWithDeps<TDeps, TSrc, TSeed>;
+      TDeps extends any[] = unknown[]> =
+      | ContextValueSpec.IsConstant<TSrc>
+      | ContextValueSpec.ViaAlias<TSrc>
+      | ContextValueSpec.ByProvider<TCtx, TSrc>
+      | ContextValueSpec.ByProviderWithDeps<TSrc, TDeps>
+      | ContextValueSpec.AsInstance<TCtx, TSrc>
+      | ContextValueSpec.SelfInstance<TCtx, TSrc>
+      | ContextValueSpec.AsInstanceWithDeps<TSrc, TDeps>
+      | ContextValueSpec.SelfInstanceWithDeps<TSrc, TDeps>;
 
   /**
    * A specifier defining a context value is constant.
    *
    * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
    */
-  export interface IsConstant<TSrc, TSeed = unknown> {
+  export interface IsConstant<TSrc> {
 
     /**
      * Target value to define.
      */
-    a: ContextTarget<TSrc, TSeed>;
+    a: ContextTarget<TSrc>;
 
     /**
      * Constant context value.
@@ -75,19 +70,18 @@ export namespace ContextValueSpec {
    * A specifier defining a context value via another one (alias).
    *
    * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
    */
-  export interface ViaAlias<TSrc, TSeed = unknown> {
+  export interface ViaAlias<TSrc> {
 
     /**
      * Target value to define.
      */
-    a: ContextTarget<TSrc, TSeed>;
+    a: ContextTarget<TSrc>;
 
     /**
      * Context value request for the another value that will be used instead as provided one.
      */
-    via: ContextRequest<TSrc, TSeed>;
+    via: ContextRequest<TSrc>;
 
   }
 
@@ -96,14 +90,13 @@ export namespace ContextValueSpec {
    *
    * @typeParam TCtx - Context type.
    * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
    */
-  export interface ByProvider<TCtx extends ContextValues, TSrc, TSeed = unknown> {
+  export interface ByProvider<TCtx extends ContextValues, TSrc> {
 
     /**
      * Target value to define.
      */
-    a: ContextTarget<TSrc, TSeed>;
+    a: ContextTarget<TSrc>;
 
     /**
      * Context value provider.
@@ -115,16 +108,15 @@ export namespace ContextValueSpec {
   /**
    * A specifier of context value defined by provider function depending on other context values.
    *
-   * @typeParam TDeps - Dependencies tuple type.
    * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
+   * @typeParam TDeps - Dependencies tuple type.
    */
-  export interface ByProviderWithDeps<TDeps extends any[], TSrc, TSeed = unknown> {
+  export interface ByProviderWithDeps<TSrc, TDeps extends any[]> {
 
     /**
      * Target value to define.
      */
-    a: ContextTarget<TSrc, TSeed>;
+    a: ContextTarget<TSrc>;
 
     /**
      * Context value provider function.
@@ -143,14 +135,13 @@ export namespace ContextValueSpec {
    *
    * @typeParam TCtx - Context type.
    * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
    */
-  export interface AsInstance<TCtx extends ContextValues, TSrc, TSeed = unknown> {
+  export interface AsInstance<TCtx extends ContextValues, TSrc> {
 
     /**
      * Target value to define.
      */
-    a: ContextTarget<TSrc, TSeed>;
+    a: ContextTarget<TSrc>;
 
     /**
      * Context value class constructor.
@@ -164,14 +155,13 @@ export namespace ContextValueSpec {
    *
    * @typeParam TCtx - Context type.
    * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
    */
-  export interface SelfInstance<TCtx extends ContextValues, TSrc, TSeed = unknown> {
+  export interface SelfInstance<TCtx extends ContextValues, TSrc> {
 
     /**
      * Target value to define as its class constructor.
      */
-    as: ContextTarget<TSrc, TSeed> & (new (context: TCtx) => TSrc);
+    as: ContextTarget<TSrc> & (new (context: TCtx) => TSrc);
 
   }
 
@@ -180,14 +170,13 @@ export namespace ContextValueSpec {
    *
    * @typeParam TDeps - Dependencies tuple type.
    * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
    */
-  export interface AsInstanceWithDeps<TDeps extends any[], TSrc, TSeed = unknown> {
+  export interface AsInstanceWithDeps<TSrc, TDeps extends any[]> {
 
     /**
      * Target value to define.
      */
-    a: ContextTarget<TSrc, TSeed>;
+    a: ContextTarget<TSrc>;
 
     /**
      * Context value class constructor.
@@ -205,16 +194,15 @@ export namespace ContextValueSpec {
    * A specifier of context value defined as instance of the same class as value with constructor depending on other
    * context values.
    *
-   * @typeParam TDeps - Dependencies tuple type.
    * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
+   * @typeParam TDeps - Dependencies tuple type.
    */
-  export interface SelfInstanceWithDeps<TDeps extends any[], TSrc, TSeed = unknown> {
+  export interface SelfInstanceWithDeps<TSrc, TDeps extends any[]> {
 
     /**
      * Target value to define as its class constructor.
      */
-    as: ContextTarget<TSrc, TSeed> & (new (...args: TDeps) => TSrc);
+    as: ContextTarget<TSrc> & (new (...args: TDeps) => TSrc);
 
     /**
      * Context value requests for corresponding constructor arguments.
@@ -241,19 +229,19 @@ export namespace ContextValueSpec {
  *
  * @typeParam TCtx - Context type.
  * @typeParam TValue - Context value type.
- * @typeParam TDeps - Dependencies tuple type.
  * @typeParam TSrc - Source value type.
+ * @typeParam TDeps - Dependencies tuple type.
  * @param spec - Explicit context value specifier to convert.
  *
  * @returns A specifier of context value defined by provider function.
  *
  * @throws TypeError  On malformed context value specifier.
  */
-export function contextValueSpec<TCtx extends ContextValues, TValue, TDeps extends any[], TSrc, TSeed>(
-    spec: ContextValueSpec.Explicit<TCtx, TValue, TDeps, TSrc, TSeed>,
-): ContextValueSpec.ByProvider<TCtx, TSrc, TSeed> {
+export function contextValueSpec<TCtx extends ContextValues, TValue, TSrc, TDeps extends any[]>(
+    spec: ContextValueSpec.Explicit<TCtx, TValue, TSrc, TDeps>,
+): ContextValueSpec.ByProvider<TCtx, TSrc> {
   if (isValueSpecByProvider(spec)) {
-    if (!isValueSpecWithDeps<TCtx, TDeps, TSrc, TSeed>(spec)) {
+    if (!isValueSpecWithDeps<TCtx, TSrc, TDeps>(spec)) {
       return spec;
     }
 
@@ -266,7 +254,7 @@ export function contextValueSpec<TCtx extends ContextValues, TValue, TDeps exten
       },
     };
   }
-  if (isConstantValueSpec<TSrc, TSeed>(spec)) {
+  if (isConstantValueSpec<TSrc>(spec)) {
 
     const { a, is: value } = spec;
 
@@ -286,11 +274,11 @@ export function contextValueSpec<TCtx extends ContextValues, TValue, TDeps exten
       },
     };
   }
-  if (isValueSpecAsInstance<TCtx, TDeps, TSrc, TSeed>(spec)) {
-    if (isSelfInstanceValueSpec<TCtx, TDeps, TSrc, TSeed>(spec)) {
+  if (isValueSpecAsInstance<TCtx, TSrc, TDeps>(spec)) {
+    if (isSelfInstanceValueSpec<TCtx, TSrc, TDeps>(spec)) {
       spec = toAsInstance(spec);
     }
-    if (!isValueSpecWithDeps<TCtx, TDeps, TSrc, TSeed>(spec)) {
+    if (!isValueSpecWithDeps<TCtx, TSrc, TDeps>(spec)) {
 
       const { as: Type } = spec;
 
@@ -318,85 +306,85 @@ export function contextValueSpec<TCtx extends ContextValues, TValue, TDeps exten
 /**
  * @internal
  */
-function isValueSpecByProvider<TCtx extends ContextValues, TDeps extends any[], TSrc, TSeed>(
-    spec: ContextValueSpec<TCtx, unknown, TDeps, TSrc, TSeed>,
+function isValueSpecByProvider<TCtx extends ContextValues, TSrc, TDeps extends any[]>(
+    spec: ContextValueSpec<TCtx, unknown, TSrc, TDeps>,
 ): spec is
-    | ContextValueSpec.ByProvider<TCtx, TSrc, TSeed>
-    | ContextValueSpec.ByProviderWithDeps<TDeps, TSrc, TSeed> {
+    | ContextValueSpec.ByProvider<TCtx, TSrc>
+    | ContextValueSpec.ByProviderWithDeps<TSrc, TDeps> {
   return 'by' in spec;
 }
 
 /**
  * @internal
  */
-function isValueSpecAsInstance<TCtx extends ContextValues, TDeps extends any[], TSrc, TSeed>(
-    spec: ContextValueSpec<TCtx, unknown, TDeps, TSrc, TSeed>,
+function isValueSpecAsInstance<TCtx extends ContextValues, TSrc, TDeps extends any[]>(
+    spec: ContextValueSpec<TCtx, unknown, TSrc, TDeps>,
 ): spec is
-    | ContextValueSpec.AsInstance<TCtx, TSrc, TSeed>
-    | ContextValueSpec.AsInstanceWithDeps<TDeps, TSrc, TSeed> {
+    | ContextValueSpec.AsInstance<TCtx, TSrc>
+    | ContextValueSpec.AsInstanceWithDeps<TSrc, TDeps> {
   return 'as' in spec;
 }
 
 /**
  * @internal
  */
-function isSelfInstanceValueSpec<TCtx extends ContextValues, TDeps extends any[], TSrc, TSeed>(
-    spec: ContextValueSpec<TCtx, unknown, TDeps, TSrc, TSeed>,
+function isSelfInstanceValueSpec<TCtx extends ContextValues, TSrc, TDeps extends any[]>(
+    spec: ContextValueSpec<TCtx, unknown, TSrc, TDeps>,
 ): spec is
-    | ContextValueSpec.SelfInstance<TCtx, TSrc, TSeed>
-    | ContextValueSpec.SelfInstanceWithDeps<TDeps, TSrc, TSeed> {
+    | ContextValueSpec.SelfInstance<TCtx, TSrc>
+    | ContextValueSpec.SelfInstanceWithDeps<TSrc, TDeps> {
   return !('a' in spec);
 }
 
 /**
  * @internal
  */
-function toAsInstance<TCtx extends ContextValues, TDeps extends any[], TSrc, TSeed>(
-    spec: ContextValueSpec.SelfInstance<TCtx, TSrc, TSeed> | ContextValueSpec.SelfInstanceWithDeps<TDeps, TSrc, TSeed>,
-): ContextValueSpec.AsInstance<TCtx, TSrc, TSeed> | ContextValueSpec.AsInstanceWithDeps<TDeps, TSrc, TSeed> {
+function toAsInstance<TCtx extends ContextValues, TSrc, TDeps extends any[]>(
+    spec: ContextValueSpec.SelfInstance<TCtx, TSrc> | ContextValueSpec.SelfInstanceWithDeps<TSrc, TDeps>,
+): ContextValueSpec.AsInstance<TCtx, TSrc> | ContextValueSpec.AsInstanceWithDeps<TSrc, TDeps> {
   return {
     ...spec,
     a: spec.as,
-  } as ContextValueSpec.AsInstance<TCtx, TSrc, TSeed> | ContextValueSpec.AsInstanceWithDeps<TDeps, TSrc, TSeed>;
+  } as ContextValueSpec.AsInstance<TCtx, TSrc> | ContextValueSpec.AsInstanceWithDeps<TSrc, TDeps>;
 }
 
 /**
  * @internal
  */
-function isConstantValueSpec<TSrc, TSeed>(
-    spec: ContextValueSpec<any, unknown, any, TSrc, TSeed>,
-): spec is ContextValueSpec.IsConstant<TSrc, TSeed> {
+function isConstantValueSpec<TSrc>(
+    spec: ContextValueSpec<any, unknown, TSrc, any>,
+): spec is ContextValueSpec.IsConstant<TSrc> {
   return 'is' in spec;
 }
 
 /**
  * @internal
  */
-function isValueSpecViaAlias<TSrc, TSeed>(
-    spec: ContextValueSpec<any, unknown, any, TSrc, TSeed>,
-): spec is ContextValueSpec.ViaAlias<TSrc, TSeed> {
+function isValueSpecViaAlias<TSrc>(
+    spec: ContextValueSpec<any, unknown, TSrc, any>,
+): spec is ContextValueSpec.ViaAlias<TSrc> {
   return 'via' in spec;
 }
 
 /**
  * @internal
  */
-function isValueSpecWithDeps<TCtx extends ContextValues, TDeps extends any[], TSrc, TSeed>(
-    spec: ContextValueSpec.ByProvider<TCtx, TSrc, TSeed> | ContextValueSpec.ByProviderWithDeps<TDeps, TSrc, TSeed>,
-): spec is ContextValueSpec.ByProviderWithDeps<TDeps, TSrc, TSeed>;
+function isValueSpecWithDeps<TCtx extends ContextValues, TSrc, TDeps extends any[]>(
+    spec: ContextValueSpec.ByProvider<TCtx, TSrc> | ContextValueSpec.ByProviderWithDeps<TSrc, TDeps>,
+): spec is ContextValueSpec.ByProviderWithDeps<TSrc, TDeps>;
 
 /**
  * @internal
  */
-function isValueSpecWithDeps<TCtx extends ContextValues, TDeps extends any[], TSrc, TSeed>(
-    spec: ContextValueSpec.AsInstance<TCtx, TSrc, TSeed> | ContextValueSpec.AsInstanceWithDeps<TDeps, TSrc, TSeed>,
-): spec is ContextValueSpec.AsInstanceWithDeps<TDeps, TSrc, TSeed>;
+function isValueSpecWithDeps<TCtx extends ContextValues, TSrc, TDeps extends any[]>(
+    spec: ContextValueSpec.AsInstance<TCtx, TSrc> | ContextValueSpec.AsInstanceWithDeps<TSrc, TDeps>,
+): spec is ContextValueSpec.AsInstanceWithDeps<TSrc, TDeps>;
 
 /**
  * @internal
  */
-function isValueSpecWithDeps<TCtx extends ContextValues, TDeps extends any[], TSrc, TSeed>(
-    spec: ContextValueSpec<TCtx, unknown, TDeps, TSrc, TSeed>,
+function isValueSpecWithDeps<TCtx extends ContextValues, TSrc, TDeps extends any[]>(
+    spec: ContextValueSpec<TCtx, unknown, TSrc, TDeps>,
 ): boolean {
   return 'with' in spec;
 }

--- a/src/registry/context-value-spec.ts
+++ b/src/registry/context-value-spec.ts
@@ -3,23 +3,7 @@ import type { ContextRequest } from '../context-request';
 import type { ContextValues } from '../context-values';
 import type { ContextBuilder } from './context-builder';
 import type { ContextTarget } from './context-target';
-
-/**
- * Context value provider.
- *
- * It is responsible for constructing the values associated with particular key for the given context. Note that
- * provider generates source value, not the context values themselves.
- *
- * @typeParam TCtx - Context type.
- * @typeParam TSrc - Source value type.
- */
-export type ContextValueProvider<TCtx extends ContextValues, TSrc> =
-/**
- * @param context - Target context.
- *
- * @return Either constructed value source, or `null`/`undefined` if unknown.
- */
-    (this: void, context: TCtx) => TSrc | null | undefined;
+import type { ContextValueProvider } from './context-value-provider';
 
 /**
  * Context value specifier.
@@ -124,7 +108,7 @@ export namespace ContextValueSpec {
     /**
      * Context value provider.
      */
-    by: ContextValueProvider<TCtx, TSrc>;
+    by: ContextValueProvider<TSrc, TCtx>;
 
   }
 

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -2,4 +2,5 @@ export * from './context-builder';
 export * from './context-registry';
 export * from './context-seeds';
 export * from './context-target';
+export * from './context-value-provider';
 export * from './context-value-spec';

--- a/src/singleton/iterative-context-key.ts
+++ b/src/singleton/iterative-context-key.ts
@@ -19,9 +19,9 @@ import type { ContextValueProvider } from '../registry';
 class IterativeContextSeeder<TCtx extends ContextValues, TSrc>
     implements ContextSeeder<TCtx, TSrc, PushIterable<TSrc>> {
 
-  private readonly _providers = new Map<Supply, ContextValueProvider<TCtx, TSrc>>();
+  private readonly _providers = new Map<Supply, ContextValueProvider<TSrc, TCtx>>();
 
-  provide(provider: ContextValueProvider<TCtx, TSrc>): Supply {
+  provide(provider: ContextValueProvider<TSrc, TCtx>): Supply {
 
     const supply = new Supply();
 
@@ -97,7 +97,7 @@ export abstract class IterativeContextKey<TValue, TSrc = TValue> extends Context
  */
 function iterativeSeed<TCtx extends ContextValues, TSrc>(
     context: TCtx,
-    providers: Map<Supply, ContextValueProvider<TCtx, TSrc>>,
+    providers: Map<Supply, ContextValueProvider<TSrc, TCtx>>,
 ): PushIterable<TSrc> {
 
   // Lazily evaluated providers

--- a/src/singleton/simple-context-key.ts
+++ b/src/singleton/simple-context-key.ts
@@ -10,12 +10,12 @@ import type { ContextValueProvider } from '../registry';
 class SimpleContextSeeder<TCtx extends ContextValues, TSrc>
     implements ContextSeeder<TCtx, TSrc, SimpleContextKey.Seed<TSrc>> {
 
-  private readonly _providers: (readonly [ContextValueProvider<TCtx, TSrc>])[] = [];
+  private readonly _providers: (readonly [ContextValueProvider<TSrc, TCtx>])[] = [];
 
-  provide(provider: ContextValueProvider<TCtx, TSrc>): Supply {
+  provide(provider: ContextValueProvider<TSrc, TCtx>): Supply {
 
     // Ensure the same provider may be registered multiple times
-    const entry: readonly [ContextValueProvider<TCtx, TSrc>] = [provider];
+    const entry: readonly [ContextValueProvider<TSrc, TCtx>] = [provider];
 
     this._providers.unshift(entry);
 
@@ -31,7 +31,7 @@ class SimpleContextSeeder<TCtx extends ContextValues, TSrc>
     }
 
     const makeSeed = (
-        [provider]: readonly [ContextValueProvider<TCtx, TSrc>],
+        [provider]: readonly [ContextValueProvider<TSrc, TCtx>],
     ): SimpleContextKey.Seed<TSrc> => lazyValue(
         provider.bind(undefined, context),
     );

--- a/src/updatable/context-up-key.ts
+++ b/src/updatable/context-up-key.ts
@@ -32,11 +32,11 @@ const flatUpSources: <TSrc>(this: void, input: AfterEvent<TSrc[][]>) => AfterEve
 class ContextUpSeeder<TCtx extends ContextValues, TSrc>
     implements ContextSeeder<TCtx, ContextUpKey.Source<TSrc>, AfterEvent<TSrc[]>> {
 
-  private readonly _providers = trackValue<[Map<Supply, ContextValueProvider<TCtx, ContextUpKey.Source<TSrc>>>]>(
+  private readonly _providers = trackValue<[Map<Supply, ContextValueProvider<ContextUpKey.Source<TSrc>, TCtx>>]>(
       [new Map()],
   );
 
-  provide(provider: ContextValueProvider<TCtx, ContextUpKey.Source<TSrc>>): Supply {
+  provide(provider: ContextValueProvider<ContextUpKey.Source<TSrc>, TCtx>): Supply {
 
     const [providers] = this._providers.it;
     const supply = new Supply();
@@ -73,7 +73,7 @@ class ContextUpSeeder<TCtx extends ContextValues, TSrc>
  */
 function upSrcKeepers<TCtx extends ContextValues, TSrc>(
     context: TCtx,
-    providersTracker: ValueTracker<[Map<Supply, ContextValueProvider<TCtx, ContextUpKey.Source<TSrc>>>]>,
+    providersTracker: ValueTracker<[Map<Supply, ContextValueProvider<ContextUpKey.Source<TSrc>, TCtx>>]>,
 ): AfterEvent<TSrc[]> {
   return providersTracker.read.do(
       digAfter_(

--- a/src/updatable/conventional/apply-context-after.ts
+++ b/src/updatable/conventional/apply-context-after.ts
@@ -1,0 +1,62 @@
+import type { AfterEvent } from '@proc7ts/fun-events';
+import { shareAfter, translateAfter_ } from '@proc7ts/fun-events';
+import { isPresent } from '@proc7ts/primitives';
+import { filterIt, mapIt } from '@proc7ts/push-iterator';
+import type { ContextValues } from '../../context-values';
+import type { Contextual } from '../../conventional';
+import { Contextual__symbol, isContextual } from '../../conventional';
+
+/**
+ * Creates an event processor that {@link applyContextTo} applies context to values and their {@link Contextual
+ * contextual references} incoming from {@link AfterEvent} keeper.
+ *
+ * This function is applicable to updatable context value {@link ContextUpKey.Source sources} potentially containing
+ * contextual references.
+ *
+ * @typeParam T - Value type.
+ * @typeParam TCtx - Supported context type.
+ * @param context - A context to apply.
+ *
+ * @returns A mapping function of `AfterEvent` keeper of values, their contextual references, or `null`/`undefined`
+ * elements to `AfterEvent` keeper of resolved values.
+ */
+export function applyContextAfter<T, TCtx extends ContextValues = ContextValues>(
+    context: TCtx,
+): (this: void, source: AfterEvent<(T | Contextual<T, TCtx> | null | undefined)[]>) => AfterEvent<T[]> {
+
+  const processor = applyContextAfter_<T, TCtx>(context);
+
+  return source => shareAfter(processor(source));
+}
+
+/**
+ * Creates an event processor that {@link applyContextTo} applies context to values and their {@link Contextual
+ * contextual references} incoming from {@link AfterEvent} keeper, and does not share the outgoing events supply.
+ *
+ * This function is applicable to updatable context value {@link ContextUpKey.Source sources} potentially containing
+ * contextual references to resolve the latter before providing to context.
+ *
+ * @typeParam T - Value type.
+ * @typeParam TCtx - Supported context type.
+ * @param context - A context to apply.
+ *
+ * @returns A mapping function of `AfterEvent` keeper of values, their contextual references, or `null`/`undefined`
+ * elements to `AfterEvent` keeper of resolved values.
+ */
+export function applyContextAfter_<// eslint-disable-line @typescript-eslint/naming-convention
+    T,
+    TCtx extends ContextValues = ContextValues>(
+    context: TCtx,
+): (this: void, source: AfterEvent<(T | Contextual<T, TCtx> | null | undefined)[]>) => AfterEvent<T[]> {
+  return translateAfter_((send, ...values) => send(
+      ...filterIt<T | null | undefined, T>(
+          mapIt(
+              values,
+              (value): T | null | undefined => isContextual(value)
+                  ? value[Contextual__symbol](context)
+                  : value,
+          ),
+          isPresent,
+      ),
+  ));
+}

--- a/src/updatable/conventional/apply-context-up.spec.ts
+++ b/src/updatable/conventional/apply-context-up.spec.ts
@@ -1,0 +1,39 @@
+import { afterThe } from '@proc7ts/fun-events';
+import { valueProvider } from '@proc7ts/primitives';
+import type { ContextValues } from '../../context-values';
+import { Contextual__symbol } from '../../conventional';
+import { ContextRegistry } from '../../registry';
+import type { SingleContextUpRef } from '../single-context-up-key';
+import { SingleContextUpKey } from '../single-context-up-key';
+import { applyContextUp } from './apply-context-up';
+
+describe('applyContextUp', () => {
+
+  let registry: ContextRegistry;
+  let context: ContextValues;
+
+  beforeEach(() => {
+    registry = new ContextRegistry();
+    context = registry.newValues();
+  });
+
+  let key: SingleContextUpRef<string>;
+
+  beforeAll(() => {
+    key = new SingleContextUpKey('test-key');
+  });
+
+  it('resolves contextual references', async () => {
+    registry.provide({ a: key, by: applyContextUp(afterThe({ [Contextual__symbol]: valueProvider('test') })) });
+    expect(await context.get(key)).toBe('test');
+  });
+  it('provides bare values', async () => {
+    registry.provide({ a: key, by: applyContextUp(afterThe('test')) });
+    expect(await context.get(key)).toBe('test');
+  });
+  it('drops `null` and `undefined` values', async () => {
+    registry.provide({ a: key, by: applyContextUp(afterThe<(string | null | undefined)[]>(undefined, null)) });
+    expect(await context.get(key, { or: afterThe('fallback') })).toBe('fallback');
+  });
+
+});

--- a/src/updatable/conventional/apply-context-up.ts
+++ b/src/updatable/conventional/apply-context-up.ts
@@ -1,0 +1,24 @@
+import type { AfterEvent } from '@proc7ts/fun-events';
+import type { ContextValues } from '../../context-values';
+import type { Contextual } from '../../conventional';
+import type { ContextValueProvider } from '../../registry';
+import { applyContextAfter } from './apply-context-after';
+
+/**
+ * Converts an `AfterEvent` keeper of values or their {@link Contextual contextual references} to context value
+ * {@link ContextValueProvider provider} of `AfterEvent` keeper of resolved values.
+ *
+ * This function is applicable to updatable context value {@link ContextUpKey.Source sources} potentially containing
+ * contextual references to resolve the latter before providing to context.
+ *
+ * @typeParam T - Value type.
+ * @typeParam TCtx - Supported context type.
+ * @param source - An `AfterEvent` keeper of values, their contextual references, or `null`/`undefined` elements.
+ *
+ * @returns Context value provider.
+ */
+export function applyContextUp<T, TCtx extends ContextValues = ContextValues>(
+    source: AfterEvent<(T | Contextual<T> | null | undefined)[]>,
+): ContextValueProvider<AfterEvent<T[]>, TCtx> {
+  return context => applyContextAfter<T, TCtx>(context)(source);
+}

--- a/src/updatable/conventional/index.ts
+++ b/src/updatable/conventional/index.ts
@@ -1,0 +1,2 @@
+export * from './apply-context-after';
+export * from './apply-context-up';

--- a/src/updatable/index.ts
+++ b/src/updatable/index.ts
@@ -4,6 +4,7 @@
  */
 export * from './context-destroyed';
 export * from './context-up-key';
+export * from './conventional';
 export * from './fn-context-key';
 export * from './multi-context-up-key';
 export * from './single-context-up-key';

--- a/src/updatable/modules/context-module.ts
+++ b/src/updatable/modules/context-module.ts
@@ -201,15 +201,14 @@ export namespace ContextModule {
      *
      * The value provider will be removed automatically once the module is unloaded.
      *
-     * @typeParam TDeps - Dependencies tuple type.
      * @typeParam TSrc - Source value type.
-     * @typeParam TSeed - Value seed type.
+     * @typeParam TDeps - Dependencies tuple type.
      * @param spec - Context value specifier.
      *
      * @returns Provider supply instance that removes just added context value provider once cut off.
      */
-    provide<TDeps extends any[], TSrc, TSeed>(
-        spec: ContextValueSpec<ContextValues, unknown, TDeps, TSrc, TSeed>,
+    provide<TSrc, TDeps extends any[]>(
+        spec: ContextValueSpec<ContextValues, unknown, TSrc, TDeps>,
     ): Supply;
 
     /**


### PR DESCRIPTION
- Add conventional `Contextual` value reference
- Change `ContextValueProvider` generic signature.
- Simplify `ContextValueSpec` generic signature
- Add `applyContextTo()` value converter
- Add `applyContextAfter()` value processor
- Add `applyContextUp()` updatable value converter
