### PR TITLE
Disallow the use of `undefined` fallback value

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -50,6 +50,7 @@ export default defineConfig({
                          // within pnpm workspace installation.
           },
         },
+        internal: ['**/impl/**', '**/*.impl.ts'],
       }),
     ],
   },

--- a/src/context-request.ts
+++ b/src/context-request.ts
@@ -34,11 +34,11 @@ export namespace ContextRequest {
     /**
      * A fallback value that will be returned if there is no value associated with target key.
      *
-     * Can be `null` or `undefined`.
+     * Can be `null`. `undefined` means there is no fallback.
      *
      * This property will be accessed only if there is no value associated with target key.
      */
-    or?: TValue | null;
+    or?: TValue | null | undefined;
 
   }
 
@@ -48,10 +48,6 @@ export namespace ContextRequest {
 
   export interface OrNull<TValue> extends Opts<TValue> {
     or: null;
-  }
-
-  export interface OrUndefined<TValue> extends Opts<TValue> {
-    or?: undefined;
   }
 
 }

--- a/src/context-values.ts
+++ b/src/context-values.ts
@@ -6,47 +6,6 @@ import type { ContextSupply } from './conventional';
  *
  * The values are available by their keys.
  */
-export abstract class ContextValues {
-
-  /**
-   * Returns a value associated with the given key.
-   *
-   * @typeParam TValue - A type of associated value.
-   * @param request - Context value request with target key.
-   * @param opts - Context value request options.
-   *
-   * @returns Associated value or `null` when there is no associated value.
-   */
-  abstract get<TValue>(request: ContextRequest<TValue>, opts: ContextRequest.OrNull<TValue>): TValue | null;
-
-  /**
-   * Returns a value associated with the given key.
-   *
-   * @typeParam TValue - A type of associated value.
-   * @param request - Context value request with target key.
-   * @param opts - Context value request options.
-   *
-   * @returns Associated value or `undefined` when there is no associated value.
-   */
-  abstract get<TValue>(request: ContextRequest<TValue>, opts: ContextRequest.OrUndefined<TValue>): TValue | undefined;
-
-  /**
-   * Returns a value associated with the given key.
-   *
-   * @typeParam TValue - A type of associated value.
-   * @param request - Context value request with target key.
-   * @param opts - Context value request options.
-   *
-   * @returns Associated value. Or the default one when there is no associated value. Or key default when there is
-   * neither.
-   *
-   * @throws Error  If there is no value associated with the given key, the default value is not provided,
-   * and the key has no default value.
-   */
-  abstract get<TValue>(request: ContextRequest<TValue>, opts?: ContextRequest.OrFallback<TValue>): TValue;
-
-}
-
 export interface ContextValues {
 
   /**
@@ -55,5 +14,41 @@ export interface ContextValues {
    * When provided, this value is available under {@link ContextSupply} key, unless overridden.
    */
   readonly supply?: ContextSupply;
+
+  /**
+   * Returns the value associated with the given key, or `null` if there is no one one.
+   *
+   * @typeParam TValue - A type of associated value.
+   * @param request - Context value request with target key.
+   * @param opts - Context value request options.
+   *
+   * @returns Either associated value, or `null` when there is no associated value.
+   */
+  get<TValue>(request: ContextRequest<TValue>, opts: ContextRequest.OrNull<TValue>): TValue | null;
+
+  /**
+   * Returns a value associated with the given key, or a fallback one.
+   *
+   * @typeParam TValue - A type of associated value.
+   * @param request - Context value request with target key.
+   * @param opts - Context value request options.
+   *
+   * @returns Either associated value, or a fallback one,.
+   */
+  get<TValue>(request: ContextRequest<TValue>, opts: ContextRequest.OrFallback<TValue>): TValue;
+
+  /**
+   * Returns a value associated with the given key.
+   *
+   * @typeParam TValue - A type of associated value.
+   * @param request - Context value request with target key.
+   * @param opts - Context value request options.
+   *
+   * @returns Either associated value, a specified fallback one, or default one when there is neither.
+   *
+   * @throws ContextKeyError  If there is no value associated with the given key, the default value is not provided,
+   * and the key has no default value.
+   */
+  get<TValue>(request: ContextRequest<TValue>, opts?: ContextRequest.Opts<TValue>): TValue;
 
 }

--- a/src/conventional/context-supply.spec.ts
+++ b/src/conventional/context-supply.spec.ts
@@ -10,7 +10,6 @@ describe('ContextSupply', () => {
     const values = new ContextRegistry().newValues();
 
     expect(values.get(ContextSupply, { or: null })).toBeNull();
-    expect(values.get(ContextSupply, { or: undefined })).toBeUndefined();
     expect(isAlwaysSupply(values.get(ContextSupply))).toBe(true);
   });
   it('is equal to the supply of context', () => {

--- a/src/conventional/context-supply.ts
+++ b/src/conventional/context-supply.ts
@@ -27,7 +27,7 @@ class ContextSupplyKey extends SimpleContextKey<ContextSupply> {
     slot.insert(
         slot.seed()
         || slot.context.supply
-        || (slot.hasFallback ? slot.or : alwaysSupply()),
+        || (slot.or !== undefined ? slot.or : alwaysSupply()),
     );
   }
 

--- a/src/key/context-seed-key.ts
+++ b/src/key/context-seed-key.ts
@@ -42,7 +42,7 @@ export abstract class ContextSeedKey<TSrc, TSeed> extends ContextKey<TSeed, TSrc
 
     if (!seeder.isEmpty(seed)) {
       opts.insert(seed);
-    } else if (!opts.hasFallback) {
+    } else if (opts.or === undefined) {
       opts.insert(seed);
     }
   }

--- a/src/key/context-value-slot.ts
+++ b/src/key/context-value-slot.ts
@@ -13,131 +13,63 @@ import type { ContextValueSetup } from './context-value-setup';
  * @typeParam TSrc - Source value type.
  * @typeParam TSeed - Value seed type.
  */
-export type ContextValueSlot<TValue, TSrc, TSeed> =
-    | ContextValueSlot.WithFallback<TValue, TSrc, TSeed>
-    | ContextValueSlot.WithoutFallback<TValue, TSrc, TSeed>;
-
-export namespace ContextValueSlot {
+export interface ContextValueSlot<TValue, TSrc, TSeed> {
 
   /**
-   * Base context value slot interface.
-   *
-   * @typeParam TValue - Context value type.
-   * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
+   * Target context.
    */
-  export interface Base<TValue, TSrc, TSeed> {
-
-    /**
-     * Target context.
-     */
-    readonly context: ContextValues;
-
-    /**
-     * A key to associate value with.
-     */
-    readonly key: ContextKey<TValue, TSrc, TSeed>;
-
-    /**
-     * Context value seeder.
-     */
-    readonly seeder: ContextSeeder<ContextValues, TSrc, TSeed>;
-
-    /**
-     * Context value seed.
-     */
-    readonly seed: TSeed;
-
-    /**
-     * Whether a {@link ContextRequest.Opts.or fallback} value has been specified.
-     */
-    readonly hasFallback: boolean;
-
-    /**
-     * A {@link ContextRequest.Opts.or fallback} value that will be used unless another one {@link insert inserted} into
-     * this slot.
-     *
-     * Can be `null` or `undefined`.
-     *
-     * Always `undefined` when {@link hasFallback there is no fallback}.
-     */
-    readonly or: TValue | null | undefined;
-
-    /**
-     * Insert the value into the slot.
-     *
-     * The value will be associated with key after {@link ContextKey.grow} method exit.
-     *
-     * Supersedes a previously inserted value.
-     *
-     * @param value - A value to associate with the key, or `null`/`undefined` to not associate any value.
-     */
-    insert(value: TValue | null | undefined): void;
-
-    /**
-     * Fills this slot by the given function.
-     *
-     * @param grow - A function accepting a value slot as its only parameter.
-     *
-     * @returns A value associated with target key by the given function, or `null`/`undefined` when no value
-     * associated.
-     */
-    fillBy(grow: (this: void, slot: ContextValueSlot<TValue, TSrc, TSeed>) => void): TValue | null | undefined;
-
-    /**
-     * Registers a setup procedure issued when context value associated with target key.
-     *
-     * Setup will be issued at most once per context. Setup won't be issued if no value {@link insert inserted}.
-     *
-     * @param setup - Context value setup procedure.
-     */
-    setup(setup: ContextValueSetup<TValue, TSrc, TSeed>): void;
-
-  }
+  readonly context: ContextValues;
 
   /**
-   * Base context value slot with fallback value.
-   *
-   * @typeParam TValue - Context value type.
-   * @typeParam TSrc - Source value type.
-   * @typeParam TSeed - Value seed type.
+   * A key to associate value with.
    */
-  export interface WithFallback<TValue, TSrc, TSeed> extends Base<TValue, TSrc, TSeed> {
+  readonly key: ContextKey<TValue, TSrc, TSeed>;
 
-    /**
-     * Whether a {@link ContextRequest.Opts.or fallback} value has been specified.
-     *
-     * Always `true`
-     */
-    readonly hasFallback: true;
+  /**
+   * Context value seeder.
+   */
+  readonly seeder: ContextSeeder<ContextValues, TSrc, TSeed>;
 
-    /**
-     * A {@link ContextRequest.Opts.or fallback} value that will be used unless another one {@link insert inserted} into
-     * this slot.
-     *
-     * Can be `null` or `undefined`.
-     */
-    readonly or: TValue | null | undefined;
+  /**
+   * Context value seed.
+   */
+  readonly seed: TSeed;
 
-  }
+  /**
+   * A {@link ContextRequest.Opts.or fallback} value that will be used unless another one {@link insert inserted} into
+   * this slot.
+   *
+   * The `undefined` value means there is no fallback.
+   */
+  readonly or: TValue | null | undefined;
 
-  export interface WithoutFallback<TValue, TSrc, TSeed> extends Base<TValue, TSrc, TSeed> {
+  /**
+   * Insert the value into the slot.
+   *
+   * The value will be associated with key after {@link ContextKey.grow} method exit.
+   *
+   * Supersedes a previously inserted value.
+   *
+   * @param value - A value to associate with the key, or `null`/`undefined` to not associate any value.
+   */
+  insert(value: TValue | null | undefined): void;
 
-    /**
-     * Whether a {@link ContextRequest.Opts.or fallback} value has been specified.
-     *
-     * Always `false`
-     */
-    readonly hasFallback: false;
+  /**
+   * Fills this slot by the given function.
+   *
+   * @param grow - A function accepting a value slot as its only parameter.
+   *
+   * @returns A value associated with target key by the given function, or `null`/`undefined` when no value
+   * associated.
+   */
+  fillBy(grow: (this: void, slot: ContextValueSlot<TValue, TSrc, TSeed>) => void): TValue | null | undefined;
 
-    /**
-     * A {@link ContextRequest.Opts.or fallback} value that will be used unless another one {@link insert inserted} into
-     * this slot.
-     *
-     * Always `undefined`.
-     */
-    readonly or: undefined;
-
-  }
-
+  /**
+   * Registers a setup procedure issued when context value associated with target key.
+   *
+   * Setup will be issued at most once per context. Setup won't be issued if no value {@link insert inserted}.
+   *
+   * @param setup - Context value setup procedure.
+   */
+  setup(setup: ContextValueSetup<TValue, TSrc, TSeed>): void;
 }

--- a/src/registry/context-registry.spec.ts
+++ b/src/registry/context-registry.spec.ts
@@ -145,7 +145,7 @@ describe('ContextRegistry', () => {
           super('test-key', { byDefault });
         }
 
-        grow(slot: ContextValueSlot<string, string, SimpleContextKey.Seed<string>>): void {
+        override grow(slot: ContextValueSlot<string, string, SimpleContextKey.Seed<string>>): void {
           super.grow(slot);
           slot.setup(setup);
         }

--- a/src/registry/context-values.impl.ts
+++ b/src/registry/context-values.impl.ts
@@ -18,7 +18,7 @@ export function newContextValues<TCtx extends ContextValues>(
 
   const values = new Map<ContextKey<any>, any>();
 
-  class ContextValues$ extends ContextValues {
+  class ContextValues$ implements ContextValues {
 
     get<TValue, TSrc>(
         this: TCtx,
@@ -51,13 +51,9 @@ export function newContextValues<TCtx extends ContextValues>(
   return new ContextValues$();
 }
 
-/**
- * @internal
- */
 class ContextValueSlot$<TCtx extends ContextValues, TValue, TSrc, TSeed>
-    implements ContextValueSlot.Base<TValue, TSrc, TSeed> {
+    implements ContextValueSlot<TValue, TSrc, TSeed> {
 
-  readonly hasFallback: boolean;
   readonly seeder: ContextSeeder<TCtx, TSrc, TSeed>;
   readonly seed: TSeed;
   private _constructed: TValue | null | undefined = null;
@@ -74,7 +70,6 @@ class ContextValueSlot$<TCtx extends ContextValues, TValue, TSrc, TSeed>
 
     this.seeder = seeder;
     this.seed = seed;
-    this.hasFallback = 'or' in _opts; // Fallback _may_ have `undefined` value.
   }
 
   get or(): TValue | null | undefined {
@@ -106,7 +101,7 @@ class ContextValueSlot$<TCtx extends ContextValues, TValue, TSrc, TSeed>
     if (this._constructed != null) {
       return [this._constructed, this._setup];
     }
-    if (!this.hasFallback) {
+    if (this.or === undefined) {
       throw new ContextKeyError(this.key);
     }
 

--- a/src/singleton/multi-context-key.spec.ts
+++ b/src/singleton/multi-context-key.spec.ts
@@ -107,17 +107,6 @@ describe('MultiContextKey', () => {
         { or: null },
     )).toBeNull();
   });
-  it('prefers `undefined` fallback value over default one', () => {
-    expect(
-        values.get(
-            new MultiContextKey<string>(
-                key.name,
-                { byDefault: () => ['default', 'value'] },
-            ),
-            { or: undefined },
-        ),
-    ).toBeUndefined();
-  });
 
   describe('combination', () => {
 

--- a/src/singleton/multi-context-key.ts
+++ b/src/singleton/multi-context-key.ts
@@ -60,7 +60,7 @@ export class MultiContextKey<TSrc>
 
     if (result.length) {
       slot.insert(result);
-    } else if (!slot.hasFallback) {
+    } else if (slot.or === undefined) {
 
       const defaultSources = this.byDefault(slot.context, this);
 

--- a/src/singleton/single-context-key.spec.ts
+++ b/src/singleton/single-context-key.spec.ts
@@ -110,10 +110,6 @@ describe('SingleContextKey', () => {
     expect(values.get(new SingleContextKey<string>(key.name, { byDefault: () => 'default' }), { or: null }))
         .toBeNull();
   });
-  it('prefers `undefined` fallback value over key one', () => {
-    expect(values.get(new SingleContextKey<string>(key.name, { byDefault: () => 'default' }), { or: undefined }))
-        .toBeUndefined();
-  });
   it('caches the value', () => {
 
     const value = 'value';

--- a/src/singleton/single-context-key.ts
+++ b/src/singleton/single-context-key.ts
@@ -56,7 +56,7 @@ export class SingleContextKey<TValue>
 
     if (value != null) {
       slot.insert(value);
-    } else if (!slot.hasFallback) {
+    } else if (slot.or === undefined) {
       slot.insert(this.byDefault(slot.context, this));
     }
   }

--- a/src/updatable/context-up-key.spec.ts
+++ b/src/updatable/context-up-key.spec.ts
@@ -26,11 +26,11 @@ describe('ContextUpKey', () => {
               // Sources present. Use them.
               return afterThe(...sources);
             }
-            if (slot.hasFallback && slot.or) {
-              return slot.or; // Backup value found.
+            if (slot.or) {
+              return slot.or; // Fallback value found.
             }
 
-            // Backup value is absent. Construct an error response.
+            // Fallback value is absent. Construct an error response.
             return afterEventBy<string[]>(() => {
               throw new ContextKeyError(this);
             });

--- a/src/updatable/fn-context-key.ts
+++ b/src/updatable/fn-context-key.ts
@@ -73,7 +73,7 @@ export class FnContextKey<TArgs extends any[], TRet = void>
             return afterThe(fns[fns.length - 1]);
           }
 
-          if (slot.hasFallback && slot.or) {
+          if (slot.or) {
             return slot.or;
           }
 
@@ -93,7 +93,7 @@ export class FnContextKey<TArgs extends any[], TRet = void>
 
     slot.context.get(
         this.upKey,
-        slot.hasFallback ? { or: slot.or != null ? afterThe(slot.or) : slot.or } : undefined,
+        slot.or != null ? { or: afterThe(slot.or) } : undefined,
     )!(
         fn => delegated = fn,
     ).whenOff(

--- a/src/updatable/modules/context-module-dependency-error.ts
+++ b/src/updatable/modules/context-module-dependency-error.ts
@@ -15,17 +15,14 @@ export class ContextModuleDependencyError extends Error {
   constructor(
       readonly module: ContextModule,
       readonly reasons: readonly (readonly [ContextModule, unknown?])[] = [],
-      readonly message: string = contextModuleDependencyErrorMessage(module, reasons),
+      message: string = ContextModuleDependencyError$defaultMessage(module, reasons),
   ) {
     super(message);
   }
 
 }
 
-/**
- * @internal
- */
-function contextModuleDependencyErrorMessage(
+function ContextModuleDependencyError$defaultMessage(
     module: ContextModule,
     dependencies: readonly (readonly [ContextModule, unknown?])[],
 ): string {

--- a/src/updatable/modules/context-module.spec.ts
+++ b/src/updatable/modules/context-module.spec.ts
@@ -532,12 +532,12 @@ describe('ContextModule', () => {
         super('test');
       }
 
-      async setup(setup: ContextModule.Setup): Promise<void> {
+      override async setup(setup: ContextModule.Setup): Promise<void> {
         await super.setup(setup);
         setup.provide({ a: key1, is: 201 });
       }
 
-      get needs(): ReadonlySet<ContextModule> {
+      override get needs(): ReadonlySet<ContextModule> {
         return new Set([this]);
       }
 

--- a/src/updatable/multi-context-up-key.spec.ts
+++ b/src/updatable/multi-context-up-key.spec.ts
@@ -78,9 +78,6 @@ describe('MultiContextUpKey', () => {
   it('cuts off the value supply if fallback value is `null`', async () => {
     expect(await Promise.resolve(values.get(key, { or: null })).catch(asis)).toBeInstanceOf(ContextKeyError);
   });
-  it('cuts off the value supply if fallback value is `undefined`', async () => {
-    expect(await Promise.resolve(values.get(key, { or: undefined })).catch(asis)).toBeInstanceOf(ContextKeyError);
-  });
   it('cuts off the value supply after context destruction', () => {
 
     const value = 'test value';

--- a/src/updatable/multi-context-up-key.ts
+++ b/src/updatable/multi-context-up-key.ts
@@ -71,22 +71,22 @@ export class MultiContextUpKey<TSrc>
         return afterThe(...sources);
       }
 
-      // Sources absent. Attempt to detect the backup value.
-      let backup: AfterEvent<TSrc[]> | null | undefined;
+      // Sources absent. Attempt to detect fallback value.
+      let fallback: AfterEvent<TSrc[]> | null | undefined;
 
-      if (slot.hasFallback) {
-        backup = slot.or;
+      if (slot.or !== undefined) {
+        fallback = slot.or;
       } else {
 
         const defaultValue = this.byDefault(slot.context, this);
 
-        backup = defaultValue != null ? afterThe(...defaultValue) : afterThe();
+        fallback = defaultValue != null ? afterThe(...defaultValue) : afterThe();
       }
-      if (backup) {
-        return backup; // Backup value found.
+      if (fallback) {
+        return fallback; // Fallback value found.
       }
 
-      // Backup value is absent. Construct an error response.
+      // Fallback value is absent. Construct an error response.
       return afterEventBy<TSrc[]>(({ supply }) => {
         supply.off(new ContextKeyError(this));
       });

--- a/src/updatable/single-context-up-key.ts
+++ b/src/updatable/single-context-up-key.ts
@@ -71,24 +71,24 @@ export class SingleContextUpKey<TValue>
         return afterThe(sources[sources.length - 1]);
       }
 
-      // Sources absent. Attempt to detect a backup value.
-      let backup: AfterEvent<[TValue]> | null | undefined;
+      // Sources absent. Attempt to detect a fallback value.
+      let fallback: AfterEvent<[TValue]> | null | undefined;
 
-      if (slot.hasFallback) {
-        backup = slot.or;
+      if (slot.or !== undefined) {
+        fallback = slot.or;
       } else {
 
         const defaultValue = this.byDefault(slot.context, this);
 
         if (defaultValue != null) {
-          backup = afterThe(defaultValue);
+          fallback = afterThe(defaultValue);
         }
       }
-      if (backup) {
-        return backup; // Backup value found.
+      if (fallback) {
+        return fallback; // Fallback value found.
       }
 
-      // Backup value is absent. Construct an error response.
+      // Fallback value is absent. Construct an error response.
       return afterEventBy<[TValue]>(({ supply }) => {
         supply.off(new ContextKeyError(this));
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,11 @@
     "target": "ES2019",
     "strict": true,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "forceConsistentCasingInFileNames": true,
-    "importsNotUsedAsValues": "error",
     "importHelpers": true,
     "noEmitHelpers": true,
     "lib": [


### PR DESCRIPTION
`{ or: undefined }` is always considered the absent fallback.
