### PR TITLE
Implement context modules

### DIFF
--- a/src/assets/alias.asset.ts
+++ b/src/assets/alias.asset.ts
@@ -20,7 +20,6 @@ export function cxAliasAsset<TAsset, TContext extends CxValues = CxValues>(
 ): CxAsset<unknown, TAsset, TContext> {
   return {
     entry,
-    supply,
     buildAssets(target, collector) {
       collector(() => {
         try {
@@ -33,5 +32,6 @@ export function cxAliasAsset<TAsset, TContext extends CxValues = CxValues>(
         }
       });
     },
+    supply,
   };
 }

--- a/src/assets/alias.asset.ts
+++ b/src/assets/alias.asset.ts
@@ -21,7 +21,7 @@ export function cxAliasAsset<TAsset, TContext extends CxValues = CxValues>(
   return {
     entry,
     supply,
-    each(target, receiver) {
+    buildAssets(target, receiver) {
       receiver(() => {
         try {
           return target.get(alias);

--- a/src/assets/alias.asset.ts
+++ b/src/assets/alias.asset.ts
@@ -21,8 +21,8 @@ export function cxAliasAsset<TAsset, TContext extends CxValues = CxValues>(
   return {
     entry,
     supply,
-    buildAssets(target, receiver) {
-      receiver(() => {
+    buildAssets(target, collector) {
+      collector(() => {
         try {
           return target.get(alias);
         } catch (reason) {

--- a/src/assets/build.asset.ts
+++ b/src/assets/build.asset.ts
@@ -21,8 +21,8 @@ export function cxBuildAsset<TValue, TAsset = TValue, TContext extends CxValues 
   return {
     entry,
     supply,
-    buildAssets(target, receiver) {
-      receiver(() => build(target));
+    buildAssets(target, collector) {
+      collector(() => build(target));
     },
   };
 }

--- a/src/assets/build.asset.ts
+++ b/src/assets/build.asset.ts
@@ -20,9 +20,9 @@ export function cxBuildAsset<TValue, TAsset = TValue, TContext extends CxValues 
 ): CxAsset<TValue, TAsset, TContext> {
   return {
     entry,
-    supply,
     buildAssets(target, collector) {
       collector(() => build(target));
     },
+    supply,
   };
 }

--- a/src/assets/build.asset.ts
+++ b/src/assets/build.asset.ts
@@ -21,7 +21,7 @@ export function cxBuildAsset<TValue, TAsset = TValue, TContext extends CxValues 
   return {
     entry,
     supply,
-    each(target, receiver) {
+    buildAssets(target, receiver) {
       receiver(() => build(target));
     },
   };

--- a/src/assets/const.asset.ts
+++ b/src/assets/const.asset.ts
@@ -21,7 +21,7 @@ export function cxConstAsset<TAsset, TContext extends CxValues = CxValues>(
   return {
     entry,
     supply,
-    each: value != null
+    buildAssets: value != null
         ? (_target, receiver) => receiver(valueProvider(value))
         : CxAsset$provideNone,
   };

--- a/src/assets/const.asset.ts
+++ b/src/assets/const.asset.ts
@@ -20,10 +20,10 @@ export function cxConstAsset<TAsset, TContext extends CxValues = CxValues>(
 ): CxAsset<unknown, TAsset, TContext> {
   return {
     entry,
-    supply,
     buildAssets: value != null
         ? (_target, collector) => collector(valueProvider(value))
         : CxAsset$provideNone,
+    supply,
   };
 }
 

--- a/src/assets/const.asset.ts
+++ b/src/assets/const.asset.ts
@@ -22,7 +22,7 @@ export function cxConstAsset<TAsset, TContext extends CxValues = CxValues>(
     entry,
     supply,
     buildAssets: value != null
-        ? (_target, receiver) => receiver(valueProvider(value))
+        ? (_target, collector) => collector(valueProvider(value))
         : CxAsset$provideNone,
   };
 }

--- a/src/build/builder.ts
+++ b/src/build/builder.ts
@@ -89,7 +89,7 @@ export class CxBuilder<TContext extends CxValues = CxValues>
 
     const { entry, supply = new Supply() } = asset;
 
-    this._record(entry).provide(asset.each, supply);
+    this._record(entry).provide(asset.buildAssets, supply);
 
     return supply;
   }

--- a/src/build/builder.ts
+++ b/src/build/builder.ts
@@ -86,12 +86,7 @@ export class CxBuilder<TContext extends CxValues = CxValues>
   }
 
   provide<TValue, TAsset = TValue>(asset: CxAsset<TValue, TAsset, TContext>): Supply {
-
-    const { entry, supply = new Supply() } = asset;
-
-    this._record(entry).provide(asset.buildAssets, supply);
-
-    return supply;
+    return this._record(asset.entry).provide(asset);
   }
 
   eachAsset<TValue, TAsset>(

--- a/src/build/entry.record.impl.ts
+++ b/src/build/entry.record.impl.ts
@@ -6,7 +6,7 @@ import { CxBuilder } from './builder';
 import { CxEntry$Target } from './entry.target.impl';
 import { CxReferenceError } from './reference-error';
 
-export type CxEntry$AssetIterator<TValue, TAsset = TValue> = CxAsset<TValue, TAsset>['each'];
+export type CxEntry$AssetIterator<TValue, TAsset = TValue> = CxAsset<TValue, TAsset>['buildAssets'];
 
 export class CxEntry$Record<TValue, TAsset, TContext extends CxValues> {
 

--- a/src/build/entry.spec.ts
+++ b/src/build/entry.spec.ts
@@ -122,7 +122,7 @@ describe('CxEntry', () => {
       });
       it('is aborted when supply cut off by asset', () => {
 
-        const entry: CxEntry<string> = {
+        const entry: CxEntry<string, number> = {
           perContext(target) {
             return {
               get() {
@@ -141,7 +141,7 @@ describe('CxEntry', () => {
         const asset: CxAsset<unknown, number> = {
           entry,
           supply: new Supply(),
-          each(target, collector) {
+          buildAssets(target, collector) {
             for (let i = 0; i < 10; ++i) {
               if (i > 2) {
                 target.supply.off();

--- a/src/core/asset.ts
+++ b/src/core/asset.ts
@@ -19,15 +19,6 @@ export interface CxAsset<TValue, TAsset = TValue, TContext extends CxValues = Cx
   readonly entry: CxEntry<TValue, TAsset>;
 
   /**
-   * Asset supply.
-   *
-   * Removes the asset once cut off.
-   *
-   * Returned from {@link CxValues.Modifier.provide} when specified. New one created when omitted.
-   */
-  readonly supply?: Supply;
-
-  /**
    * Builds assets for the `target` context entry.
    *
    * Passes each {@link CxAsset.Evaluator asset evaluator} to the given `collector`, until the latter returns `false`
@@ -40,6 +31,15 @@ export interface CxAsset<TValue, TAsset = TValue, TContext extends CxValues = Cx
       target: CxEntry.Target<TValue, TAsset, TContext>,
       collector: CxAsset.Collector<TAsset>,
   ): void;
+
+  /**
+   * Asset supply.
+   *
+   * Removes the asset once cut off.
+   *
+   * Returned from {@link CxValues.Modifier.provide} when specified. New one created when omitted.
+   */
+  readonly supply?: Supply;
 
 }
 

--- a/src/core/asset.ts
+++ b/src/core/asset.ts
@@ -33,6 +33,17 @@ export interface CxAsset<TValue, TAsset = TValue, TContext extends CxValues = Cx
   ): void;
 
   /**
+   * Sets up asset.
+   *
+   * This method is called immediately when asset {@link CxValues.Modifier.provide provided}.
+   *
+   * It can be used e.g. to provide additional assets. Additional assets will be revoked when the asset itself revoked.
+   *
+   * @param target - Context entry definition target.
+   */
+  setupAsset?(target: CxEntry.Target<TValue, TAsset, TContext>): void;
+
+  /**
    * Asset supply.
    *
    * Removes the asset once cut off.

--- a/src/core/asset.ts
+++ b/src/core/asset.ts
@@ -5,7 +5,7 @@ import { CxValues } from './values';
 /**
  * Context entry asset.
  *
- * Used to provide assets of the value of specific context entry.
+ * Builds assets for the value of specific context entry.
  *
  * @typeParam TValue - Context value type.
  * @typeParam TAsset - Context value asset type.
@@ -28,15 +28,15 @@ export interface CxAsset<TValue, TAsset = TValue, TContext extends CxValues = Cx
   readonly supply?: Supply;
 
   /**
-   * Passes each {@link CxAsset.Evaluator asset evaluator} provided for the `target` context entry to the given
-   * `collector`.
+   * Builds assets for the `target` context entry.
    *
-   * Calls `collector` with each evaluator, until the latter returns `false` or there are no more assets.
+   * Passes each {@link CxAsset.Evaluator asset evaluator} to the given `collector`, until the latter returns `false`
+   * or there are no more assets.
    *
    * @param target - Context entry definition target.
    * @param collector - Asset evaluators collector.
    */
-  each(
+  buildAssets(
       this: void,
       target: CxEntry.Target<TValue, TAsset, TContext>,
       collector: CxAsset.Collector<TAsset>,
@@ -56,7 +56,7 @@ export namespace CxAsset {
   export type Evaluator<TAsset> = (this: void) => TAsset | null | undefined;
 
   /**
-   * A signature of context value {@link CxAsset.each asset evaluators iteration} callback.
+   * A signature of context value {@link CxAsset.buildAssets asset evaluators iteration} callback.
    *
    * @typeParam TAsset - Context value asset type.
    * @param getAsset - Asset evaluator.

--- a/src/core/asset.ts
+++ b/src/core/asset.ts
@@ -37,7 +37,6 @@ export interface CxAsset<TValue, TAsset = TValue, TContext extends CxValues = Cx
    * @param collector - Asset evaluators collector.
    */
   buildAssets(
-      this: void,
       target: CxEntry.Target<TValue, TAsset, TContext>,
       collector: CxAsset.Collector<TAsset>,
   ): void;
@@ -56,12 +55,12 @@ export namespace CxAsset {
   export type Evaluator<TAsset> = (this: void) => TAsset | null | undefined;
 
   /**
-   * A signature of context value {@link CxAsset.buildAssets asset evaluators iteration} callback.
+   * A signature of context value {@link CxAsset.buildAssets asset evaluators} collector.
    *
    * @typeParam TAsset - Context value asset type.
-   * @param getAsset - Asset evaluator.
+   * @param getAsset - Asset evaluator to collect.
    *
-   * @returns `false` to stop iteration, or `true`/`void` to continue.
+   * @returns `false` to stop collecting, or `true`/`void` to continue.
    */
   export type Collector<TAsset> = (this: void, getAsset: Evaluator<TAsset>) => void | boolean;
 

--- a/src/core/values.ts
+++ b/src/core/values.ts
@@ -30,9 +30,11 @@ export namespace CxValues {
     readonly context: TContext;
 
     /**
-     * Provides assets for the target context entry.
+     * Provides assets for context {@link CxAsset.entry entry}.
      *
-     * @param asset - Context entry asset. Removes the provided asset when removed.
+     * @param asset - Context entry asset.
+     *
+     * @returns Assets supply. Revokes provided assets once cut off.
      */
     provide<TValue, TAsset = TValue>(asset: CxAsset<TValue, TAsset, TContext>): Supply;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from './context-ref';
 export * from './context-values';
 export * from './conventional';
 export * from './core';
+export * from './modules';
 export * from './registry';
 export * from './singleton';
 export * from './key';

--- a/src/modules/dependency-error.spec.ts
+++ b/src/modules/dependency-error.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from '@jest/globals';
+import { CxDependencyError } from './dependency-error';
+import { CxModule } from './module';
+
+describe('CxDependencyError', () => {
+  describe('message', () => {
+    it('reflects multiple reasons', () => {
+
+      const error = new CxDependencyError(
+          new CxModule('test'),
+          [
+            [new CxModule('dep1')],
+            [new CxModule('dep2'), 'reason 2'],
+          ],
+      );
+
+      expect(error.message).toBe(
+          'Failed to load [CxModule test]: '
+          + '[CxModule dep1] not loaded, [CxModule dep2] failed to load (reason 2)',
+      );
+    });
+    it('reflects no reasons', () => {
+
+      const error = new CxDependencyError(new CxModule('test'));
+
+      expect(error.message).toBe('Failed to load [CxModule test]');
+    });
+  });
+});

--- a/src/modules/dependency-error.ts
+++ b/src/modules/dependency-error.ts
@@ -1,0 +1,49 @@
+import type { CxModule } from './module';
+
+/**
+ * An error indicating context module dependency load failure.
+ */
+export class CxDependencyError extends Error {
+
+  /**
+   * Constructs context module dependency load error.
+   *
+   * @param module - A module failed to load.
+   * @param reasons - An array of dependency/reason pairs caused the load failure.
+   * @param message - An error message.
+   */
+  constructor(
+      readonly module: CxModule,
+      readonly reasons: readonly (readonly [CxModule, unknown?])[] = [],
+      message: string = ContextModuleDependencyError$defaultMessage(module, reasons),
+  ) {
+    super(message);
+  }
+
+}
+
+function ContextModuleDependencyError$defaultMessage(
+    module: CxModule,
+    dependencies: readonly (readonly [CxModule, unknown?])[],
+): string {
+
+  const reasons = dependencies.reduce(
+      (out, [dep, reason]) => {
+        if (out) {
+          out += ', ';
+        } else {
+          out = ': ';
+        }
+        if (reason !== undefined) {
+          out += `${dep} failed to load (${reason})`;
+        } else {
+          out += `${dep} not loaded`;
+        }
+
+        return out;
+      },
+      '',
+  );
+
+  return `Failed to load ${module}${reasons}`;
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,0 +1,2 @@
+export * from './dependency-error';
+export * from './module';

--- a/src/modules/module.impl.ts
+++ b/src/modules/module.impl.ts
@@ -1,0 +1,162 @@
+import type { OnEvent } from '@proc7ts/fun-events';
+import { AfterEvent, afterEventBy, sendEventsTo } from '@proc7ts/fun-events';
+import { isDefined, noop, setOfElements, valueProvider } from '@proc7ts/primitives';
+import { itsElements, valueIt } from '@proc7ts/push-iterator';
+import { CxAsset, CxEntry } from '../core';
+import { CxDependencyError } from './dependency-error';
+import type { CxModule } from './module';
+
+export const CxModule$Impl__symbol = (/*#__PURE__*/ Symbol('ContextModule.impl'));
+
+export class CxModule$Impl {
+
+  readonly has: ReadonlySet<CxModule>;
+  readonly needs: ReadonlySet<CxModule>;
+
+  private readonly _setup: (
+      this: void,
+      setup: CxModule.Setup,
+  ) => void | PromiseLike<unknown>;
+
+  constructor(readonly module: CxModule, readonly name: string, readonly options: CxModule.Options) {
+
+    const { needs, has, setup } = options;
+
+    this.has = setOfElements(has).add(module);
+    this.needs = setOfElements(needs);
+    this._setup = setup ? setup.bind(options) : noop;
+  }
+
+  async setup(setup: CxModule.Setup): Promise<void> {
+
+    const deps = CxModule$deps(setup);
+
+    // Await for module dependencies to be settled.
+    if (!await CxModule$loadDeps(setup, deps, CxModule$whenSettled)) {
+      return;
+    }
+
+    setup.initBy(async () => {
+      // Initialize module dependencies.
+      await CxModule$loadDeps(setup, deps, CxModule$whenReady);
+    });
+
+    await this._setup(setup);
+  }
+
+}
+
+export function CxModule$replace(replaced: CxModule, replacer: CxModule): CxAsset<CxModule.Handle, CxModule> {
+
+  const replacement = valueProvider(replacer);
+
+  return {
+    entry: replaced,
+    buildAssets(_target, collector) {
+      collector(replacement);
+    },
+  };
+}
+
+export function CxModule$implement(
+    target: CxEntry.Target<CxModule.Handle, CxModule>,
+): AfterEvent<[CxModule | undefined]> {
+
+  const module = target.entry;
+
+  return afterEventBy<[CxModule | undefined]>(receiver => {
+
+    const receive = sendEventsTo(receiver);
+
+    target.trackAssetList(candidates => {
+
+      let impl: CxModule | null | undefined;
+
+      for (let i = candidates.length - 1; i >= 0; --i) {
+
+        const candidate = candidates[i].get();
+
+        impl = candidate;
+        if (candidate !== module) {
+          break;
+        }
+      }
+
+      receive(impl || undefined);
+    }).needs(receiver.supply);
+  });
+}
+
+interface CxModule$Dep {
+  readonly dep: CxModule;
+  readonly use: CxModule.Use;
+}
+
+function CxModule$deps(setup: CxModule.Setup): readonly CxModule$Dep[] {
+
+  const { module, supply } = setup;
+
+  return itsElements(
+      valueIt(
+          module.needs,
+          dep => dep !== module
+              && setup.provide(dep).needs(supply)
+              && {
+                dep,
+                use: setup.get(dep).use(setup),
+              },
+      ),
+  );
+}
+
+function CxModule$loadDeps(
+    setup: CxModule.Setup,
+    deps: readonly CxModule$Dep[],
+    whenLoaded: (use: CxModule.Use) => OnEvent<[CxModule.Status]>,
+): Promise<boolean> {
+
+  const { module, supply } = setup;
+  const notLoaded = valueProvider(false);
+  const whenDone = supply.whenDone().then(notLoaded, notLoaded);
+
+  return Promise.race([
+    whenDone,
+    Promise
+        .all(
+            deps
+                .map(
+                    ({ dep, use }) => whenLoaded(use).then(
+                        noop,
+                        error => [dep, error] as const,
+                    ),
+                ),
+        )
+        .then(
+            (results): true | CxDependencyError => {
+
+              const failures = results.filter<readonly [CxModule, unknown]>(isDefined);
+
+              return failures.length
+                  ? new CxDependencyError(module, failures) // Prevent unhandled promise rejection
+                  : true as const;
+            },
+        ),
+  ]).then(
+      result => {
+        if (typeof result !== 'boolean') {
+          // Fail to load module if at leas one of its dependencies failed.
+          return Promise.reject(result);
+        }
+
+        return result;
+      },
+  );
+}
+
+function CxModule$whenSettled(use: CxModule.Use): OnEvent<[CxModule.Status]> {
+  return use.whenSettled;
+}
+
+function CxModule$whenReady(use: CxModule.Use): OnEvent<[CxModule.Status]> {
+  return use.whenReady;
+}

--- a/src/modules/module.spec.ts
+++ b/src/modules/module.spec.ts
@@ -1,0 +1,788 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { asis, newPromiseResolver, noop } from '@proc7ts/primitives';
+import { Supply } from '@proc7ts/supply';
+import { cxConstAsset } from '../assets';
+import { CxBuilder } from '../build';
+import { cxDynamic, CxEntry, cxRecent, CxValues } from '../core';
+import { CxDependencyError } from './dependency-error';
+import { CxModule } from './module';
+
+describe('CxModule', () => {
+
+  const entry1: CxEntry<number> = { perContext: cxRecent({ byDefault: () => 1 }) };
+  const entry2: CxEntry<number> = { perContext: cxRecent({ byDefault: () => 2 }) };
+
+  let builder: CxBuilder;
+  let context: CxValues;
+
+  beforeEach(() => {
+    builder = new CxBuilder(get => ({ get }));
+    context = builder.context;
+  });
+
+  it('provides value when loaded', async () => {
+
+    const module = new CxModule(
+        'test',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+          },
+        },
+    );
+    const supply = builder.provide(module);
+
+    expect(context.get(entry1)).toBe(1);
+    expect(await context.get(module).read).toMatchObject({
+      module,
+      provided: true,
+      used: false,
+      settled: false,
+      ready: false,
+    });
+
+    expect(await context.get(module).use().whenReady).toMatchObject({
+      module,
+      provided: true,
+      used: true,
+      settled: true,
+      ready: true,
+    });
+    expect(context.get(entry1)).toBe(101);
+
+    supply.off();
+    expect(context.get(entry1)).toBe(1);
+    expect(await context.get(module).read).toMatchObject({
+      module,
+      provided: false,
+      used: true,
+      settled: false,
+      ready: false,
+    });
+  });
+  it('provides value by initializer', async () => {
+
+    const resolver = newPromiseResolver();
+    const module = new CxModule(
+        'test',
+        {
+          setup(setup) {
+            setup.initBy(async () => {
+              await resolver.promise();
+              setup.provide(cxConstAsset(entry1, 101));
+            });
+          },
+        },
+    );
+    const supply = builder.provide(module);
+
+    expect(context.get(entry1)).toBe(1);
+    expect(await context.get(module).read).toMatchObject({
+      module,
+      provided: true,
+      used: false,
+      settled: false,
+      ready: false,
+    });
+
+    expect(await context.get(module).use().whenSettled).toMatchObject({
+      module,
+      provided: true,
+      used: true,
+      settled: true,
+      ready: false,
+    });
+    expect(context.get(entry1)).toBe(1);
+
+    resolver.resolve();
+    expect(await context.get(module).use().whenReady).toMatchObject({
+      module,
+      provided: true,
+      used: true,
+      settled: true,
+      ready: true,
+    });
+    expect(context.get(entry1)).toBe(101);
+
+    supply.off();
+    expect(context.get(entry1)).toBe(1);
+    expect(await context.get(module).read).toMatchObject({
+      module,
+      provided: false,
+      used: true,
+      settled: false,
+      ready: false,
+    });
+  });
+  it('provides value by initializer inside initializer', async () => {
+
+    const resolver = newPromiseResolver();
+    const module = new CxModule(
+        'test',
+        {
+          setup(setup) {
+            setup.initBy(() => {
+              setup.initBy(async () => {
+                await resolver.promise();
+                setup.provide(cxConstAsset(entry1, 101));
+              });
+            });
+          },
+        },
+    );
+    const supply = builder.provide(module);
+
+    expect(context.get(entry1)).toBe(1);
+    expect(await context.get(module).read).toMatchObject({
+      module,
+      provided: true,
+      used: false,
+      settled: false,
+      ready: false,
+    });
+
+    expect(await context.get(module).use().whenSettled).toMatchObject({
+      module,
+      provided: true,
+      used: true,
+      settled: true,
+      ready: false,
+    });
+    expect(context.get(entry1)).toBe(1);
+
+    resolver.resolve();
+    expect(await context.get(module).use().whenReady).toMatchObject({
+      module,
+      provided: true,
+      used: true,
+      settled: true,
+      ready: true,
+    });
+    expect(context.get(entry1)).toBe(101);
+
+    supply.off();
+    expect(context.get(entry1)).toBe(1);
+    expect(await context.get(module).read).toMatchObject({
+      module,
+      provided: false,
+      used: true,
+      settled: false,
+      ready: false,
+    });
+  });
+  it('loaded once', async () => {
+
+    const entry: CxEntry<readonly number[], number> = { perContext: cxDynamic({ byDefault: () => [0] }) };
+    const module = new CxModule(
+        'test',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry, 1));
+            setup.provide(cxConstAsset(entry, 2));
+          },
+        },
+    );
+    const supply1 = builder.provide(module);
+    const supply2 = builder.provide(module);
+
+    expect(context.get(entry)).toEqual([0]);
+
+    expect(await context.get(module).use().whenReady).toMatchObject({
+      module,
+      provided: true,
+      used: true,
+      settled: true,
+      ready: true,
+    });
+    expect(context.get(entry)).toEqual([1, 2]);
+
+    supply1.off();
+    await Promise.resolve();
+    expect(await context.get(module).use().whenReady).toMatchObject({
+      module,
+      provided: true,
+      used: true,
+      settled: true,
+      ready: true,
+    });
+    expect(context.get(entry)).toEqual([1, 2]);
+
+    supply2.off();
+    expect(context.get(entry)).toEqual([0]);
+    expect(await context.get(module).read).toMatchObject({
+      module,
+      provided: false,
+      used: true,
+      settled: false,
+      ready: false,
+    });
+  });
+  it('never loaded when user supply is cut off', async () => {
+
+    const module = new CxModule(
+        'test',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+          },
+        },
+    );
+
+    builder.provide(module);
+
+    const handle = context.get(module);
+    const use = handle.use(new Supply(noop).off('reason'));
+
+    await Promise.resolve();
+    expect(await handle.read).toMatchObject({
+      module,
+      provided: true,
+      used: false,
+      settled: false,
+      ready: false,
+    });
+    expect(await Promise.resolve(use.read).catch(asis)).toBe('reason');
+    expect(context.get(entry1)).toBe(1);
+  });
+  it('unloaded when no more users', async () => {
+
+    const module = new CxModule(
+        'test',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+          },
+        },
+    );
+
+    builder.provide(module);
+
+    const use1 = context.get(module).use();
+    const use2 = use1.use();
+
+    expect(await use1.whenReady).toMatchObject({ module, ready: true });
+    expect(context.get(entry1)).toBe(101);
+
+    use1.supply.off();
+    await Promise.resolve();
+    expect(await use2.read).toMatchObject({ module, ready: true });
+    expect(context.get(entry1)).toBe(101);
+
+    use2.supply.off();
+    expect(context.get(entry1)).toBe(1);
+  });
+  it('reports load failure', async () => {
+
+    const error = new Error('test');
+    const module = new CxModule(
+        'test',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+            throw error;
+          },
+        },
+    );
+
+    builder.provide(module);
+
+    const use = context.get(module).use();
+
+    expect(await whenFailed(module)).toBe(error);
+    expect(context.get(entry1)).toBe(1);
+
+    use.supply.off();
+    expect(await whenStatus(module, status => status.error === undefined && status)).toMatchObject({
+      module,
+      provided: false,
+      used: false,
+      settled: false,
+      ready: false,
+    });
+  });
+  it('reports init failure', async () => {
+
+    const error = new Error('test');
+    const module = new CxModule(
+        'test',
+        {
+          setup(setup) {
+            setup.initBy(() => {
+              setup.provide(cxConstAsset(entry1, 101));
+              throw error;
+            });
+          },
+        },
+    );
+
+    builder.provide(module);
+
+    const use = context.get(module).use();
+
+    expect(await whenFailed(module)).toBe(error);
+    expect(context.get(entry1)).toBe(1);
+
+    use.supply.off();
+    expect(await whenStatus(module, status => status.error === undefined && status)).toMatchObject({
+      module,
+      provided: false,
+      used: false,
+      settled: false,
+      ready: false,
+    });
+  });
+  it('rejects initializer when initialization complete', async () => {
+
+    const whenInit = newPromiseResolver();
+    const afterInit = newPromiseResolver();
+    const module = new CxModule(
+        'test',
+        {
+          setup(setup) {
+            setup.initBy(() => {
+
+              const result = Promise.resolve();
+
+              // eslint-disable-next-line jest/valid-expect-in-promise
+              afterInit.resolve(result.then(async () => {
+                await whenInit.promise();
+                setup.initBy(noop);
+              }));
+
+              return result;
+            });
+          },
+        },
+    );
+
+    builder.provide(module);
+
+    await context.get(module).use().whenReady;
+    whenInit.resolve();
+
+    const error: Error = await afterInit.promise().catch(asis);
+
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error.message).toBe('[CxModule test] initialized already, and does not accept new initializers');
+
+  });
+  it('loads dependency', async () => {
+
+    const dep = new CxModule(
+        'dep',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+          },
+        },
+    );
+    const module = new CxModule(
+        'test',
+        {
+          needs: dep,
+          setup(setup) {
+            setup.provide(cxConstAsset(entry2, 102));
+          },
+        },
+    );
+    const supply = builder.provide(module);
+
+    expect(context.get(entry1)).toBe(1);
+    expect(context.get(entry2)).toBe(2);
+
+    expect(await context.get(module).use().whenReady).toMatchObject({
+      module,
+      provided: true,
+      used: true,
+      settled: true,
+      ready: true,
+    });
+    expect(context.get(entry1)).toBe(101);
+    expect(context.get(entry2)).toBe(102);
+
+    supply.off();
+    expect(context.get(entry1)).toBe(1);
+    expect(context.get(entry2)).toBe(2);
+    expect(await context.get(module).read).toMatchObject({
+      module,
+      provided: false,
+      used: true,
+      settled: false,
+      ready: false,
+    });
+  });
+  it('handles preliminary module unload', async () => {
+
+    const dep = new CxModule(
+        'dep',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+          },
+        },
+    );
+    const module = new CxModule(
+        'test',
+        {
+          needs: dep,
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 201));
+          },
+        },
+    );
+    const supply = builder.provide(module);
+
+    expect(context.get(entry1)).toBe(1);
+
+    const read = context.get(module).use().read;
+
+    supply.off();
+
+    expect(await read).toMatchObject({
+      module,
+      provided: false,
+      used: true,
+      settled: false,
+      ready: false,
+    });
+    expect(context.get(entry1)).toBe(1);
+  });
+  it('handles preliminary module deactivation', async () => {
+
+    const dep = new CxModule(
+        'dep',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+          },
+        },
+    );
+    const module = new CxModule(
+        'test',
+        {
+          needs: dep,
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 201));
+          },
+        },
+    );
+
+    builder.provide(module);
+
+    expect(context.get(entry1)).toBe(1);
+
+    const handle = context.get(module);
+    const use = handle.use();
+
+    use.supply.whenOff(noop).off('reason');
+
+    expect(await handle.read).toMatchObject({
+      module,
+      provided: true,
+      used: false,
+      settled: false,
+      ready: false,
+    });
+    expect(await Promise.resolve(use.read).catch(asis)).toBe('reason');
+    expect(context.get(entry1)).toBe(1);
+  });
+  it('sets up after dependency', async () => {
+
+    const dep = new CxModule(
+        'dep',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+          },
+        },
+    );
+    const module = new CxModule(
+        'test',
+        {
+          needs: dep,
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 201));
+          },
+        },
+    );
+    const supply = builder.provide(module);
+
+    expect(context.get(entry1)).toBe(1);
+
+    expect(await context.get(module).use().whenReady).toMatchObject({ module, ready: true });
+    expect(context.get(entry1)).toBe(201);
+
+    supply.off();
+    expect(context.get(entry1)).toBe(1);
+  });
+  it('handles itself as a dependency', async () => {
+
+    class TestModule extends CxModule {
+
+      constructor() {
+        super('test');
+      }
+
+      override async setup(setup: CxModule.Setup): Promise<void> {
+        await super.setup(setup);
+        setup.provide(cxConstAsset(entry1, 201));
+      }
+
+      override get needs(): ReadonlySet<CxModule> {
+        return new Set([this]);
+      }
+
+    }
+
+    const module = new TestModule();
+    const supply = builder.provide(module);
+
+    expect(context.get(entry1)).toBe(1);
+
+    expect(await context.get(module).use().whenReady).toMatchObject({ module, ready: true });
+    expect(context.get(entry1)).toBe(201);
+
+    supply.off();
+    expect(context.get(entry1)).toBe(1);
+  });
+  it('fails to load on dependency load failure', async () => {
+
+    const error = new Error('test');
+    const dep = new CxModule(
+        'dep',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+            throw error;
+          },
+        },
+    );
+    const module = new CxModule(
+        'test',
+        {
+          needs: dep,
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 201));
+          },
+        },
+    );
+
+    builder.provide(module);
+    context.get(module).use();
+
+    const failure = (await whenFailed(module)) as CxDependencyError;
+
+    expect(failure).toBeInstanceOf(CxDependencyError);
+    expect(failure.module).toBe(module);
+    expect(failure.reasons).toEqual([[dep, error]]);
+    expect(await context.get(module).read).toMatchObject({
+      module,
+      provided: false,
+      used: true,
+      ready: false,
+      settled: false,
+      error: failure,
+    });
+    expect(context.get(entry1)).toBe(1);
+  });
+  it('fails to load on dependency init failure', async () => {
+
+    const error = new Error('test');
+    const dep = new CxModule(
+        'dep',
+        {
+          setup(setup) {
+            setup.initBy(() => {
+              setup.provide(cxConstAsset(entry1, 101));
+              throw error;
+            });
+          },
+        },
+    );
+    const module = new CxModule(
+        'test',
+        {
+          needs: dep,
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 201));
+          },
+        },
+    );
+
+    builder.provide(module);
+    context.get(module).use();
+
+    const failure = (await whenFailed(module)) as CxDependencyError;
+
+    expect(failure).toBeInstanceOf(CxDependencyError);
+    expect(failure.module).toBe(module);
+    expect(failure.reasons).toEqual([[dep, error]]);
+    expect(await context.get(module).read).toMatchObject({
+      module,
+      provided: false,
+      used: true,
+      ready: false,
+      settled: false,
+      error: failure,
+    });
+    expect(context.get(entry1)).toBe(1);
+  });
+  it('replaces other module when explicitly loaded', async () => {
+
+    const replaced = new CxModule(
+        'replaced',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+          },
+        },
+    );
+
+    expect(context.get(entry1)).toBe(1);
+    expect(context.get(entry2)).toBe(2);
+
+    const replacedSupply = builder.provide(replaced);
+
+    expect(await context.get(replaced).use().whenReady).toMatchObject({ module: replaced, ready: true });
+    expect(context.get(entry1)).toBe(101);
+
+    const replacer = new CxModule(
+        'replacer',
+        {
+          has: replaced,
+          setup(setup) {
+            setup.provide(cxConstAsset(entry2, 102));
+          },
+        },
+    );
+    const replacerSupply = builder.provide(replacer);
+
+    context.get(replacer).use();
+    await whenImplementedBy(replacer, replacer);
+
+    context.get(replaced).use();
+    await whenImplementedBy(replaced, replacer);
+    expect(context.get(entry1)).toBe(1);
+    expect(context.get(entry2)).toBe(102);
+
+    replacerSupply.off();
+    await whenImplementedBy(replaced, replaced);
+    expect(context.get(entry1)).toBe(101);
+    expect(context.get(entry2)).toBe(2);
+
+    replacedSupply.off();
+    expect(context.get(entry1)).toBe(1);
+    expect(context.get(entry2)).toBe(2);
+  });
+  it('implicitly loaded on replaced module use', async () => {
+
+    const replaced = new CxModule(
+        'replaced',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+          },
+        },
+    );
+
+    expect(context.get(entry1)).toBe(1);
+    expect(context.get(entry2)).toBe(2);
+
+    const replacedSupply = builder.provide(replaced);
+
+    const replacer = new CxModule(
+        'test',
+        {
+          has: replaced,
+          setup(setup) {
+            setup.provide(cxConstAsset(entry2, 102));
+          },
+        },
+    );
+
+    builder.provide(replacer);
+    context.get(replaced).use();
+    await whenImplementedBy(replaced, replacer);
+    expect(context.get(entry1)).toBe(1);
+    expect(context.get(entry2)).toBe(102);
+
+    replacedSupply.off();
+    expect(context.get(entry1)).toBe(1);
+    expect(context.get(entry2)).toBe(102);
+    expect(await context.get(replaced).read).toMatchObject({
+      module: replaced,
+      provided: true,
+      used: true,
+      settled: true,
+      ready: true,
+    });
+  });
+  it('handles immediate module replacement', async () => {
+
+    const replaced = new CxModule(
+        'replaced',
+        {
+          setup(setup) {
+            setup.provide(cxConstAsset(entry1, 101));
+          },
+        },
+    );
+
+    builder.provide(replaced);
+
+    const replacedUse = context.get(replaced).use();
+
+    const replacer = new CxModule(
+        'test',
+        {
+          has: replaced,
+          setup(setup) {
+            setup.provide(cxConstAsset(entry2, 102));
+          },
+        },
+    );
+    const replacerSupply = builder.provide(replacer);
+
+    expect(await replacedUse.whenReady).toMatchObject({ module: replacer, ready: true });
+    expect(context.get(entry1)).toBe(1);
+    expect(context.get(entry2)).toBe(102);
+
+    replacerSupply.off();
+    await whenImplementedBy(replaced, replaced);
+    expect(context.get(entry1)).toBe(101);
+    expect(context.get(entry2)).toBe(2);
+  });
+
+  describe('toString', () => {
+    it('builds module string representation', () => {
+      expect(new CxModule('test').toString()).toBe('[CxModule test]');
+    });
+  });
+
+  function whenStatus<T>(
+      target: CxModule,
+      checkStatus: (status: CxModule.Status) => T | false | null | undefined,
+  ): Promise<T> {
+    return new Promise(resolve => context.get(target).read(
+        status => {
+
+          const result = checkStatus(status);
+
+          if (result) {
+            resolve(result);
+          }
+        },
+    ));
+  }
+
+  function whenImplementedBy(target: CxModule, impl: CxModule): Promise<unknown> {
+    return whenStatus(
+        target,
+        ({ module, provided, ready }) => ready && provided && module === impl,
+    );
+  }
+
+  function whenFailed(target: CxModule): Promise<unknown> {
+    return whenStatus(target, ({ error }) => error);
+  }
+});

--- a/src/modules/module.ts
+++ b/src/modules/module.ts
@@ -1,0 +1,384 @@
+import { AfterEvent, EventKeeper, OnEvent } from '@proc7ts/fun-events';
+import { lazyValue, valueProvider } from '@proc7ts/primitives';
+import { Supply, SupplyPeer } from '@proc7ts/supply';
+import { CxAsset, CxEntry, CxValues } from '../core';
+import { CxModule$Impl, CxModule$Impl__symbol, CxModule$implement, CxModule$replace } from './module.impl';
+import { CxModule$Usage } from './module.usage.impl';
+
+/**
+ * Context module.
+ *
+ * Modules intended to extend the context dynamically.
+ *
+ * The module is a context entry that can be used to provide module instance and access its
+ * {@link CxModule.Handle handle}.
+ *
+ * Usage example:
+ * ```typescript
+ * // Construct new module.
+ * const myModule = new CxModule('my module', {
+ *   setup(setup) {
+ *     // Provide the values
+ *     setup.provide({ a: Foo, is: 'foo' });
+ *   },
+ * });
+ *
+ * // Load the module
+ * const myModuleSupply = contextBuilder.provide(myModule);
+ *
+ * // Start using the module
+ * const myModuleUse = await context.get(myModule).use();
+ *
+ * // Await for the module to load
+ * await myModuleUse.whenReady;
+ *
+ * // Access the value provided by module.
+ * console.log(context.get(Foo));
+ *
+ * // Stop using the module
+ * myModuleUse.supply.off();
+ *
+ * // Unload the module declaration.
+ * myModuleSupply.off();
+ * ```
+ */
+export class CxModule implements CxEntry<CxModule.Handle, CxModule>, CxAsset<CxModule.Handle, CxModule> {
+
+  /**
+   * @internal
+   */
+  private readonly [CxModule$Impl__symbol]: CxModule$Impl;
+
+  /**
+   * Constructs context module.
+   *
+   * @param name - Human-readable module name.
+   * @param options - Module construction options.
+   */
+  constructor(name: string, options: CxModule.Options = {}) {
+    this[CxModule$Impl__symbol] = new CxModule$Impl(this, name, options);
+  }
+
+  /**
+   * Human-readable module name.
+   */
+  get name(): string {
+    return this[CxModule$Impl__symbol].name;
+  }
+
+  get [Symbol.toStringTag](): string {
+    return this.name;
+  }
+
+  get entry(): this {
+    return this;
+  }
+
+  /**
+   * The modules this one requires.
+   *
+   * Assigned by {@link CxModule.Options.needs} option.
+   */
+  get needs(): ReadonlySet<CxModule> {
+    return this[CxModule$Impl__symbol].needs;
+  }
+
+  /**
+   * The modules this one provides.
+   *
+   * Assigned by {@link CxModule.Options.has} option.
+   *
+   * Always contains the module itself.
+   */
+  get has(): ReadonlySet<CxModule> {
+    return this[CxModule$Impl__symbol].has;
+  }
+
+  perContext(target: CxEntry.Target<CxModule.Handle, CxModule>): CxEntry.Definition<CxModule.Handle> {
+
+    const getUsageAndHandle = lazyValue<[CxModule$Usage, CxModule.Handle]>(() => {
+
+      const usage = new CxModule$Usage(target.context, this);
+
+      return [usage, usage.createHandle()];
+    });
+    let getHandle = (): CxModule.Handle => {
+
+      const [usage, handle] = getUsageAndHandle();
+
+      getHandle = valueProvider(handle); // Allow to receive handle before setup completes.
+
+      // Set up only once.
+      usage.setup(target);
+      usage.implementBy(CxModule$implement(target));
+
+      return handle;
+    };
+
+    return {
+      get: () => getHandle(),
+    };
+  }
+
+  buildAssets(
+      _target: CxEntry.Target<CxModule.Handle, CxModule>,
+      collector: CxAsset.Collector<CxModule>,
+  ): void {
+    collector(valueProvider(this));
+  }
+
+  setupAsset(target: CxEntry.Target<CxModule.Handle, CxModule>): void {
+    for (const replaced of this.has) {
+      if (replaced !== this && replaced !== target.entry) {
+        target.provide(CxModule$replace(replaced, this));
+      }
+    }
+  }
+
+  /**
+   * Sets up the module.
+   *
+   * This method is called when loading the module. It is used e.g. to provide more values for the context.
+   *
+   * By default:
+   *
+   * 1. Satisfies module {@link needs dependencies} by setting them up.
+   *
+   *    The dependency considered satisfied when it is {@link CxModule.Status.settled settled}.
+   *
+   * 2. {@link CxModule.Setup.initBy Initializes} the module by initializing the dependencies.
+   *
+   *    The dependency considered initialized when it is {@link CxModule.Status.ready ready for use}.
+   *
+   * 3. Performs the module setup by invoking the {@link CxModule.Options.setup} method.
+   *
+   * @param setup - Context module setup.
+   *
+   * @returns A promise resolved when the module is set up asynchronously.
+   */
+  setup(setup: CxModule.Setup): Promise<void> {
+    return this[CxModule$Impl__symbol].setup(setup);
+  }
+
+  toString(): string {
+    return `[CxModule ${this[Symbol.toStringTag]}]`;
+  }
+
+}
+
+export namespace CxModule {
+
+  /**
+   * Context module construction options.
+   */
+  export interface Options {
+
+    /**
+     * A module or modules the constructed one requires.
+     *
+     * The listed modules will be loaded prior to loading the constructed one.
+     */
+    readonly needs?: CxModule | readonly CxModule[];
+
+    /**
+     * A module or modules the constructed one provides.
+     *
+     * When specified, the constructed module will be loaded _instead_ of the listed ones.
+     *
+     * The module always provides itself.
+     */
+    readonly has?: CxModule | readonly CxModule[];
+
+    /**
+     * Sets up constructed module.
+     *
+     * This method is called when loading the module. It is used e.g. to provide more values for the context.
+     *
+     * @param setup - Context module setup.
+     *
+     * @returns Either nothing to set up the module synchronously, or a promise-like instance resolved when the module
+     * is set up asynchronously.
+     */
+    setup?(setup: CxModule.Setup): void | PromiseLike<unknown>;
+
+  }
+
+  /**
+   * Context module setup.
+   *
+   * Passed to {@link CxModule.setup module setup method} in order to access and provide the necessary values.
+   *
+   * @typeParam TCtx - Target context type.
+   */
+  export interface Setup extends CxValues, CxValues.Modifier, SupplyPeer {
+
+    /**
+     * The module to set up.
+     */
+    readonly module: CxModule;
+
+    /**
+     * Module supply.
+     *
+     * This supply will be cut off once the module is unloaded.
+     */
+    readonly supply: Supply;
+
+    /**
+     * Provides assets for context {@link CxAsset.entry entry}.
+     *
+     * The asset will be revoked automatically once the module is unloaded.
+     *
+     * @param asset - Context entry asset.
+     *
+     * @returns Assets supply. Revokes provided assets once cut off.
+     */
+    provide<TValue, TAsset = TValue>(asset: CxAsset<TValue, TAsset>): Supply;
+
+    /**
+     * Registers the module initializer.
+     *
+     * The module initializer registration is only valid during its {@link CxModule.setup setup}.
+     *
+     * The registered initializers executed after successful module {@link CxModule.setup}. The modules
+     * is considered {@link CxModule.Status.ready ready for use} only when all registered initializers succeed.
+     *
+     * The registered initializers executed serially. I.e. then next one does not start until the previous one succeeds.
+     *
+     * It is an error calling this method when the module initialized already.
+     *
+     * @param init - The module initialization function, that returns nothing when the module initialization
+     * completed synchronously, or a promise-like instance resolved when the module initialization completed
+     * asynchronously.
+     */
+    initBy(init: (this: void) => void | PromiseLike<unknown>): void;
+
+  }
+
+  /**
+   * A handle of dynamically loaded context module.
+   *
+   * Available as module entry {@link CxValues.get value}.
+   *
+   * Implements an `EventKeeper` interface by sending a {@link CxModule.Status module load status} updates.
+   */
+  export interface Handle extends EventKeeper<[CxModule.Status]> {
+
+    /**
+     * An `AfterEvent` keeper of module load status.
+     *
+     * The `[AfterEvent__symbol]` property is an alias of this one.
+     */
+    readonly read: AfterEvent<[CxModule.Status]>;
+
+    /**
+     * Initiate the module use.
+     *
+     * @param user - Module user. Contains a supply required by {@link Use.supply module use supply}. The module use
+     * stops once the user supply is cut off.
+     *
+     * @returns A module usage instance.
+     */
+    use(user?: SupplyPeer): Use;
+
+  }
+
+  /**
+   * An instance of the module use.
+   *
+   * The module is active while it is in use. I.e. at least one `Use` instance exists and active.
+   *
+   * The use is active util its {@link supply} is cut off.
+   *
+   * The module use instance can be used as its handle too.
+   */
+  export interface Use extends Handle, SupplyPeer {
+
+    /**
+     * An `AfterEvent` keeper of module load status.
+     *
+     * The `[AfterEvent__symbol]` property is an alias of this one.
+     *
+     * Cuts off the supply when context module no longer {@link supply used}.
+     */
+    readonly read: AfterEvent<[CxModule.Status]>;
+
+    /**
+     * An `OnEvent` sender of the module settlement event.
+     *
+     * Sends the {@link CxModule.Status loaded module status} when it is {@link CxModule.Status.settled settled}, but
+     * possibly before it is {@link CxModule.Status.ready ready}.
+     *
+     * Cuts off the supply when context module {@link CxModule.Status.error failed to load} or no longer
+     * {@link supply used}.
+     */
+    readonly whenSettled: OnEvent<[CxModule.Status]>;
+
+    /**
+     * An `OnEvent` sender of the module readiness event.
+     *
+     * Sends the {@link CxModule.Status loaded module status} when it is {@link CxModule.Status.ready ready
+     * for use}.
+     *
+     * Cuts off the supply when context module {@link CxModule.Status.error failed to load} or no longer
+     * {@link supply used}.
+     */
+    readonly whenReady: OnEvent<[CxModule.Status]>;
+
+    /**
+     * Module use supply.
+     *
+     * The module use stops once this supply is cut off.
+     */
+    readonly supply: Supply;
+
+  }
+
+  /**
+   * Context module load status.
+   *
+   * This status is reported by {@link CxModule.Handle loaded module handle}.
+   */
+  export interface Status {
+
+    /**
+     * Loaded module.
+     *
+     * Note that it may differ from the one requested to load. E.g. when another module {@link CxModule.Options.has
+     * provides} it.
+     */
+    readonly module: CxModule;
+
+    /**
+     * Whether the module implementation provided.
+     */
+    readonly provided: boolean;
+
+    /**
+     * Whether the module is {@link Handle.use used} at least once.
+     */
+    readonly used: boolean;
+
+    /**
+     * Whether the module settled.
+     *
+     * The module is settled when its {@link CxModule.setup set up} is complete.
+     */
+    readonly settled: boolean;
+
+    /**
+     * Whether the module loaded and ready for use.
+     *
+     * The module is ready when it is {@link settled}, and all of its {@link CxModule.Setup.initBy initializers}
+     * succeed.
+     */
+    readonly ready: boolean;
+
+    /**
+     * Error occurred while loading the module.
+     */
+    readonly error?: unknown;
+
+  }
+
+}

--- a/src/modules/module.usage.impl.ts
+++ b/src/modules/module.usage.impl.ts
@@ -1,0 +1,313 @@
+import {
+  AfterEvent,
+  AfterEvent__symbol,
+  mapAfter_,
+  OnEvent,
+  onEventBy,
+  supplyAfter,
+  trackValue,
+  ValueTracker,
+} from '@proc7ts/fun-events';
+import { noop, valueProvider } from '@proc7ts/primitives';
+import { neverSupply, Supply, SupplyPeer } from '@proc7ts/supply';
+import { CxSupply } from '../conventional';
+import { CxAsset, CxEntry, CxRequest, CxValues } from '../core';
+import type { CxModule } from './module';
+
+export class CxModule$Usage {
+
+  private readonly _impl: ValueTracker<CxModule | undefined>;
+  private readonly _rev: ValueTracker<ContextModuleRev>;
+  private _useCounter = 0;
+
+  private _setup!: () => void;
+
+  constructor(context: CxValues, readonly module: CxModule) {
+    this._impl = trackValue();
+    this._rev = trackValue({
+      status: {
+        module: this.module,
+        provided: false,
+        used: false,
+        settled: false,
+        ready: false,
+      },
+      supply: neverSupply(),
+    });
+
+    const contextSupply = context.get(CxSupply);
+
+    contextSupply.cuts(this._impl);
+    contextSupply.cuts(this._rev);
+
+    this._impl.read(module => {
+
+      const prevSupply = this._rev.it.supply;
+
+      if (module) {
+        this._load(module);
+      }
+
+      prevSupply.off();
+    });
+  }
+
+  createHandle(): CxModule.Handle {
+
+    const read: AfterEvent<[CxModule.Status]> = this._rev.read.do(
+        mapAfter_(({ status }) => status),
+    );
+
+    const handle: CxModule.Handle = {
+      read,
+      [AfterEvent__symbol]: valueProvider(read),
+      use: (user?: SupplyPeer) => this._use(handle, user),
+    };
+
+    return handle;
+  }
+
+  setup(target: CxEntry.Target<CxModule.Handle, CxModule>): void {
+    this._setup = () => {
+
+      const rev = this._rev.it;
+      const { status: { module }, supply } = rev;
+
+      if (module !== this.module) {
+        // Load implementation module instead.
+        // The implementation module expected to be provided already.
+        target.get(module).use(supply).read({
+          supply,
+          receive: (_ctx, { settled, ready, error }) => {
+            this._updateStatus(rev, settled, ready, error);
+          },
+        });
+      } else {
+        loadContextModule(target, rev)
+            .then(({ whenReady }) => {
+              this._updateStatus(rev, true, false);
+              return whenReady;
+            })
+            .then(() => this._updateStatus(rev, true, true))
+            .catch(error => rev.supply.off(error));
+      }
+    };
+  }
+
+  implementBy(impl: AfterEvent<[CxModule?]>): void {
+    this._impl.by(impl);
+  }
+
+  private _updateStatus(
+      rev: ContextModuleRev,
+      settled: boolean,
+      ready: boolean,
+      error?: unknown,
+  ): void {
+    // Ensure updating the correct revision.
+    if (this._rev.it.supply !== rev.supply) {
+      // If revision changed, then drop the obsolete one.
+      rev.supply.off();
+    } else {
+      this._rev.it = rev = {
+        status: {
+          module: rev.status.module,
+          provided: rev.status.provided,
+          used: true,
+          settled,
+          ready,
+          error,
+        },
+        supply: rev.supply,
+      };
+    }
+  }
+
+  private _load(module: CxModule): void {
+
+    const supply = new Supply(noop).needs(this._rev).whenOff(error => {
+
+      const rev = this._rev.it;
+
+      if (rev.supply === supply) {
+        this._rev.it = {
+          status: {
+            ...this._rev.it.status,
+            provided: false,
+            settled: false,
+            ready: false,
+            error,
+          },
+          supply,
+        };
+      }
+    });
+
+    const used = !!this._useCounter;
+
+    this._rev.it = {
+      status: {
+        module,
+        provided: true,
+        used,
+        settled: false,
+        ready: false,
+      },
+      supply,
+    };
+
+    if (used) {
+      this._setup();
+    }
+  }
+
+  private _use(handle: CxModule.Handle, user?: SupplyPeer): CxModule.Use {
+
+    const supply = new Supply(noop);
+
+    if (user) {
+      supply.needs(user);
+    }
+
+    const read = handle.read.do(supplyAfter(supply));
+    const use: CxModule.Use = {
+      ...handle,
+      read,
+      whenSettled: ContextModule$Use$when(read, isContextModuleSettled),
+      whenReady: ContextModule$Use$when(read, isContextModuleReady),
+      supply,
+    };
+
+    if (!supply.isOff) {
+      supply.whenOff(error => {
+        if (!--this._useCounter) {
+
+          const rev = this._rev.it;
+
+          this._rev.it = {
+            status: {
+              ...rev.status,
+              used: false,
+              settled: false,
+              ready: false,
+              error,
+            },
+            supply: new Supply(noop).off(error),
+          };
+
+          rev.supply.off(error);
+        }
+      });
+
+      if (!this._useCounter++) {
+        // Mark the module used and set it up.
+
+        const rev = this._rev.it;
+
+        this._rev.it = {
+          status: {
+            ...rev.status,
+            used: true,
+          },
+          supply: rev.supply,
+        };
+
+        this._setup();
+      }
+    }
+
+    return use;
+  }
+
+}
+
+interface ContextModuleRev {
+
+  readonly status: CxModule.Status;
+  readonly supply: Supply;
+
+}
+
+async function loadContextModule(
+    target: CxEntry.Target<CxModule.Handle, CxModule>,
+    { status: { module }, supply }: ContextModuleRev,
+): Promise<ContextModuleInit> {
+
+  const moduleInit = new ContextModuleInit(module);
+
+  await module.setup({
+
+    context: target.context,
+    module,
+    supply,
+
+    get<TValue>(entry: CxEntry<TValue, any>, request?: CxRequest<TValue>): TValue | null {
+      return target.get(entry, request);
+    },
+
+    provide<TValue, TAsset = TValue>(asset: CxAsset<TValue, TAsset>): Supply {
+      return target.provide(asset).needs(supply);
+    },
+
+    initBy(init: (this: void) => (void | PromiseLike<unknown>)) {
+      moduleInit.initBy(init);
+    },
+
+  });
+
+  return moduleInit;
+}
+
+class ContextModuleInit {
+
+  readonly whenReady: Promise<unknown>;
+  private _whenDone: Promise<unknown> = Promise.resolve();
+  private _ready!: (result?: PromiseLike<unknown>) => void;
+
+  constructor(private readonly _module: CxModule) {
+    this.whenReady = new Promise(resolve => this._ready = resolve);
+  }
+
+  initBy(init: (this: void) => void | PromiseLike<unknown>): void {
+
+    const rev: Promise<unknown> = this._whenDone = this._whenDone
+        .then(init)
+        .finally(() => this._done(rev));
+
+  }
+
+  private _done(rev: Promise<unknown>): void {
+    if (this._whenDone === rev) {
+      this._ready(rev);
+      this.initBy = _init => {
+        throw new TypeError(`${this._module} initialized already, and does not accept new initializers`);
+      };
+    }
+  }
+
+}
+
+function ContextModule$Use$when(
+    status: AfterEvent<[CxModule.Status]>,
+    test: (status: CxModule.Status) => boolean,
+): OnEvent<[CxModule.Status]> {
+  return onEventBy(receiver => status({
+    supply: receiver.supply,
+    receive: (context, status) => {
+      if (test(status)) {
+        receiver.receive(context, status);
+        receiver.supply.off();
+      } else if (status.error) {
+        receiver.supply.off(status.error);
+      }
+    },
+  }));
+}
+
+function isContextModuleSettled({ settled }: CxModule.Status): boolean {
+  return settled;
+}
+
+function isContextModuleReady({ ready }: CxModule.Status): boolean {
+  return ready;
+}


### PR DESCRIPTION
- Rename `CxAsset.each()` to `.buildAssets()`
- Refine `CxAsset` interface
- Implement context modules as context entries and assets
