### PR TITLE
Precise value requests

### DIFF
--- a/src/core/entry.ts
+++ b/src/core/entry.ts
@@ -1,6 +1,7 @@
 import { Supply, SupplyPeer } from '@proc7ts/supply';
 import { CxAsset } from './asset';
 import { CxRequest } from './request';
+import { CxRequestMethod } from './request-method';
 import { CxValues } from './values';
 
 /**
@@ -164,7 +165,7 @@ export namespace CxEntry {
   export interface Definition<TValue> {
 
     /**
-     * Assigns context entry value.
+     * Assigns context entry value {@link CxValues.Modifier.provide provided} by its assets.
      *
      * When defined, this method is tried first when accessing the context entry value.
      *
@@ -172,7 +173,7 @@ export namespace CxEntry {
      * is not available, the {@link assignDefault default value} is used instead.
      *
      * @param assigner - Entry value assigner to call if the value is available.
-     * @param request - Context value {@link CxValues.get request}.
+     * @param request - Original context value {@link CxValues.get request}.
      */
     assign?(assigner: Assigner<TValue>, request: CxRequest<TValue>): void;
 
@@ -183,8 +184,9 @@ export namespace CxEntry {
      * {@link CxRequest.or fallback} provided.
      *
      * @param assigner - Entry value assigner to call if the value is available.
+     * @param request - Original context value {@link CxValues.get request}.
      */
-    assignDefault?(assigner: Assigner<TValue>): void;
+    assignDefault?(assigner: Assigner<TValue>, request: CxRequest<TValue>): void;
 
   }
 
@@ -195,7 +197,9 @@ export namespace CxEntry {
    *
    * @typeParam TValue - Context value type.
    * @param value - Assigned entry value.
+   * @param by - Optional request method the value is obtained by. By default, depends on {@link Definition entry
+   * definition} method the assigner passed to.
    */
-  export type Assigner<TValue> = (this: void, value: TValue) => void;
+  export type Assigner<TValue> = (this: void, value: TValue, by?: CxRequestMethod) => void;
 
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -7,4 +7,5 @@ export * from './entries';
 export * from './entry';
 export * from './reference-error';
 export * from './request';
+export * from './request-method';
 export * from './values';

--- a/src/core/request-method.ts
+++ b/src/core/request-method.ts
@@ -1,0 +1,43 @@
+/**
+ * Context value request method.
+ *
+ * {@link CxRequest.by Specifies} how to obtain the value.
+ */
+export const enum CxRequestMethod {
+
+  /**
+   * Requests any available value.
+   *
+   * The same as if no {@link CxRequest.by request method} specified.
+   *
+   * Calls {@link CxEntry.Definition.assign} method. If no value assigned, calls
+   * {@link CxEntry.Definition.assignDefault} one. If no value assigned in turn, uses a {@link CxRequest.or fallback}
+   * one if specified, or throws {@link CxReferenceError} otherwise.
+   *
+   * When passed to {@link CxRequest.get} callback means the assigned value is a {@link CxRequest.or fallback} one.
+   */
+  Fallback = 0,
+
+  /**
+   * Requests the value by context entry defaults.
+   *
+   * Calls {@link CxEntry.Definition.assignDefault} method. If no value assigned, uses a {@link CxRequest.or fallback}
+   * one if specified, or throws {@link CxReferenceError} otherwise.
+   *
+   * When passed to {@link CxRequest.get} callback means the value is a {@link CxEntry.Definition.assignDefault default}
+   * one.
+   */
+  Defaults = -1,
+
+  /**
+   * Requests the value {@link CxValues.Modifier.provide provided} by context entry assets.
+   *
+   * Calls {@link CxEntry.Definition.assign} method. If no value assigned, uses a {@link CxRequest.or fallback} one
+   * if specified, or throws {@link CxReferenceError} otherwise.
+   *
+   * When passed to {@link CxRequest.get} callback means the value is {@link CxEntry.Definition.assign provided} by
+   * entry assets.
+   */
+  Assets = 1,
+
+}

--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -1,3 +1,5 @@
+import { CxRequestMethod } from './request-method';
+
 /**
  * Context value request.
  *
@@ -14,6 +16,26 @@ export interface CxRequest<TValue> {
    */
   readonly or?: TValue | null | undefined;
 
+  /**
+   * Request method.
+   *
+   * Specifies how to obtain the value. E.g. it can be used to request only {@link CxRequestMethod.Defaults default}
+   * one.
+   */
+  readonly by?: CxRequestMethod;
+
+  /**
+   * Assigns the value.
+   *
+   * When specified, this method is called right before returning the value from {@link CxValues.get} call. It won't be
+   * called if there is no value to return.
+   *
+   * @param value - The {@link CxEntry.Definition.assign value} or {@link CxEntry.Definition.assignDefault default
+   * value} assigned to entry, or a {@link or fallback} one.
+   * @param by - The request method the value is obtained by.
+   */
+  set?(this: void, value: TValue | null, by: CxRequestMethod): void;
+
 }
 
 export namespace CxRequest {
@@ -21,7 +43,7 @@ export namespace CxRequest {
   /**
    * Context value request with fallback specified.
    *
-   * This can be passed to {@link CxValues.get} method as second parameter.
+   * Can be passed to {@link CxValues.get} method as second parameter.
    *
    * @typeParam TValue - Requested context value type.
    */
@@ -31,6 +53,23 @@ export namespace CxRequest {
      * A fallback value to use if there is no value {@link Definition.assign available} for requested entry.
      */
     readonly or: TValue;
+
+    set?(this: void, value: TValue, by: CxRequestMethod): void;
+
+  }
+
+  /**
+   * Context value request without fallback specified.
+   *
+   * Can be passed to {@link CxValues.get} method as second parameter.
+   *
+   * @typeParam TValue - Requested context value type.
+   */
+  export interface WithoutFallback<TValue> extends CxRequest<TValue> {
+
+    readonly or?: undefined;
+
+    set?(this: void, value: TValue, by: CxRequestMethod): void;
 
   }
 

--- a/src/core/values.ts
+++ b/src/core/values.ts
@@ -46,7 +46,7 @@ export namespace CxValues {
   export interface Accessor {
 
     /**
-     * Obtains a value of the given entry, or returns a fallback one.
+     * Obtains a value of the given context entry.
      *
      * @typeParam TValue - Requested context value type.
      * @param entry - Context entry to obtain the value of.
@@ -54,10 +54,21 @@ export namespace CxValues {
      *
      * @returns Either context entry value, or a fallback one.
      */
-    get<TValue>(entry: CxEntry<TValue, any>, request?: CxRequest.WithFallback<TValue>): TValue;
+    get<TValue>(entry: CxEntry<TValue, unknown>, request?: CxRequest.WithoutFallback<TValue>): TValue;
 
     /**
-     * Obtains a value of the given entry.
+     * Obtains a value of the given context entry, or returns a non-nullable fallback.
+     *
+     * @typeParam TValue - Requested context value type.
+     * @param entry - Context entry to obtain the value of.
+     * @param request - Context value request with fallback specified.
+     *
+     * @returns Either context entry value, or a fallback one.
+     */
+    get<TValue>(entry: CxEntry<TValue, unknown>, request: CxRequest.WithFallback<TValue>): TValue;
+
+    /**
+     * Obtains a value of the given context entry, or returns a nullable fallback.
      *
      * @typeParam TValue - Requested context value type.
      * @param entry - Context entry to obtain the value of.
@@ -67,7 +78,7 @@ export namespace CxValues {
      *
      * @throws CxReferenceError - If the target `entry` has no value and fallback one is not provided.
      */
-    get<TValue>(entry: CxEntry<TValue, any>, request?: CxRequest<TValue>): TValue | null;
+    get<TValue>(entry: CxEntry<TValue, unknown>, request?: CxRequest<TValue>): TValue | null;
 
   }
 
@@ -77,7 +88,22 @@ export namespace CxValues {
   export interface Getter {
 
     /**
-     * Obtains a value of the given context entry, or returns a fallback one.
+     * Obtains a value of the given context entry.
+     *
+     * @typeParam TValue - Requested context value type.
+     * @param entry - Context entry to obtain the value of.
+     * @param request - Context value request with fallback specified.
+     *
+     * @returns Either context entry value, or a fallback one.
+     */
+    <TValue>(
+        this: void,
+        entry: CxEntry<TValue, unknown>,
+        request?: CxRequest.WithoutFallback<TValue>,
+    ): TValue;
+
+    /**
+     * Obtains a value of the given context entry, or returns a non-nullable fallback.
      *
      * @typeParam TValue - Requested context value type.
      * @param entry - Context entry to obtain the value of.
@@ -88,11 +114,11 @@ export namespace CxValues {
     <TValue>(
         this: void,
         entry: CxEntry<TValue, any>,
-        request?: CxRequest.WithFallback<TValue>,
+        request: CxRequest.WithFallback<TValue>,
     ): TValue;
 
     /**
-     * Obtains a value of the given context entry.
+     * Obtains a value of the given context entry, or returns a nullable fallback.
      *
      * @typeParam TValue - Requested context value type.
      * @param entry - Context entry to obtain the value of.


### PR DESCRIPTION
- Add `CxRequest.by` to select value request method.
  E.g. to request only provided values, or only default ones.
- Add `CxRequest.set` to call with evaluated value result.
