### PR TITLE
Respect request method

### DIFF
--- a/src/core/asset.ts
+++ b/src/core/asset.ts
@@ -25,7 +25,7 @@ export interface CxAsset<TValue, TAsset = TValue, TContext extends CxValues = Cx
    * to place.
    *
    * @param target - Context entry definition target.
-   * @param collector - Asset collector.
+   * @param collector - Assets collector to place assets to.
    */
   placeAsset(
       target: CxEntry.Target<TValue, TAsset, TContext>,
@@ -57,36 +57,16 @@ export interface CxAsset<TValue, TAsset = TValue, TContext extends CxValues = Cx
 export namespace CxAsset {
 
   /**
-   * Context value asset placeholder.
-   *
-   * A placeholder could be {@link CxAsset.placeAsset placed} instead of the value asset. In this case it will be used
-   * to evaluate and place assets instead.
-   *
-   * @typeParam TAsset - Context value asset type.
-   */
-  export interface Placeholder<TAsset> {
-
-    /**
-     * Evaluates value asset or multiple assets and places them to `target` context entry.
-     *
-     * @param target - Context entry definition target.
-     * @param callback - Asset placement callback.
-     */
-    placeAsset(target: CxEntry.Target<unknown, TAsset>, callback: Callback<TAsset>): void;
-
-  }
-
-  /**
-   * A signature of context value asset collector.
+   * A signature of context value assets collector.
    *
    * The {@link CxAsset.placeAsset} method passes evaluated assets to it.
    *
    * @typeParam TAsset - Context value asset type.
-   * @param asset - Either asset instance to collect, or its resolver.
+   * @param asset - Asset to collect.
    *
    * @returns `false` to stop collecting, or `true`/`void` to continue.
    */
-  export type Collector<TAsset> = (this: void, asset: TAsset | Placeholder<TAsset>) => void | boolean;
+  export type Collector<TAsset> = (this: void, asset: TAsset) => void | boolean;
 
   /**
    * A signature of {@link CxEntry.Target.eachAsset assets iteration} callback.

--- a/src/core/reference-error.spec.ts
+++ b/src/core/reference-error.spec.ts
@@ -19,6 +19,7 @@ describe('CxReferenceError', () => {
     expect(error.entry).toBe(entry);
     expect(error.message).toBe('The [CxEntry test] has no value');
     expect(error.reason).toBeUndefined();
+    expect(String(error)).toBe('CxReferenceError: The [CxEntry test] has no value');
   });
   it('accepts custom message', () => {
 
@@ -27,6 +28,7 @@ describe('CxReferenceError', () => {
     expect(error.entry).toBe(entry);
     expect(error.message).toBe('Test');
     expect(error.reason).toBeUndefined();
+    expect(String(error)).toBe('CxReferenceError: Test');
   });
   it('accepts reason', () => {
 
@@ -34,7 +36,8 @@ describe('CxReferenceError', () => {
     const error = new CxReferenceError(entry, undefined, reason);
 
     expect(error.entry).toBe(entry);
-    expect(error.message).toBe('The [CxEntry test] has no value');
+    expect(error.message).toBe('The [CxEntry test] has no value. Error: Test');
     expect(error.reason).toBe(reason);
+    expect(String(error)).toBe('CxReferenceError: The [CxEntry test] has no value. Error: Test');
   });
 });

--- a/src/core/reference-error.ts
+++ b/src/core/reference-error.ts
@@ -23,9 +23,13 @@ export class CxReferenceError extends ReferenceError {
    * @param reason - Original error reason.
    */
   constructor(entry: CxEntry<any>, message = `The ${entry} has no value`, reason?: unknown) {
-    super(message);
+    super(reason === undefined ? message : `${message}. ${reason}`);
     this.entry = entry;
     this.reason = reason;
+  }
+
+  override get name(): string {
+    return 'CxReferenceError';
   }
 
 }


### PR DESCRIPTION
- `cxRecent()`: Do not access unavailable default value
- `cxScoped()`: Properly handle fallback values
- Proper error messages
- Drop support for asset placeholders
- `cxDynamic()`: Do not access unavailable default value
